### PR TITLE
Decorate the auth controllers and views for each request

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,19 +66,19 @@ app.
 
 Simply call the generator to copy all views into your host app:
 ```bash
-$ bundle exec rails g solidus:views:override
+$ bundle exec rails g solidus_starter_frontend:views:override
 ```
 
 If you only want to copy certain views into your host app, you can provide the
 `--only` argument:
 ```bash
-$ bundle exec rails g solidus:views:override --only products/show
+$ bundle exec rails g solidus_starter_frontend:views:override --only products/show
 ```
 
 The argument to `--only` can also be a substring of the name of the view from
 the `app/views/spree` folder:
 ```bash
-$ bundle exec rails g solidus:views:override --only product
+$ bundle exec rails g solidus_starter_frontend:views:override --only product
 ```
 
 ## About

--- a/lib/solidus_starter_frontend/engine.rb
+++ b/lib/solidus_starter_frontend/engine.rb
@@ -14,7 +14,7 @@ module SolidusStarterFrontend
       g.test_framework :rspec
     end
 
-    config.after_initialize do
+    config.to_prepare do
       if defined?(Spree::Auth::Engine)
         [
           Spree::UserConfirmationsController,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Replace `after_initialize` with `to_prepare` to prepend the gem 
controllers and views for every request overriding the other extensions.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Using the `after_initialize` method, the application overrides the controllers and the view once.
We have to give the priority to solidus_starter_frontend for each request.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
