### PR TITLE
Update orders controller and specs to match Solidus

### DIFF
--- a/spec/controllers/spree/current_order_tracking_spec.rb
+++ b/spec/controllers/spree/current_order_tracking_spec.rb
@@ -31,17 +31,3 @@ describe 'current order tracking', type: :controller do
     end
   end
 end
-
-describe Spree::OrdersController, type: :controller do
-  let(:user) { create(:user) }
-
-  before { allow(controller).to receive_messages(try_spree_current_user: user) }
-
-  describe Spree::OrdersController do
-    it "doesn't create a new order out of the blue" do
-      expect {
-        get :edit
-      }.not_to change { Spree::Order.count }
-    end
-  end
-end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Updates in Solidus caused the specs for the orders controller to break. Porting the new version of the file from Solidus fixes the issue.

These are the 2 PRs that updated the storefront files:
- https://github.com/solidusio/solidus/pull/3494
- https://github.com/solidusio/solidus/pull/3645

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
