### PR TITLE
Remove code that generate deprecation warnings

### DIFF
--- a/app/controllers/spree/checkout_controller.rb
+++ b/app/controllers/spree/checkout_controller.rb
@@ -98,10 +98,6 @@ module Spree
       massaged_params = params.deep_dup
 
       move_payment_source_into_payments_attributes(massaged_params)
-      if massaged_params[:order] && massaged_params[:order][:existing_card].present?
-        Spree::Deprecation.warn("Passing order[:existing_card] is deprecated. Send order[:wallet_payment_source_id] instead.", caller)
-        move_existing_card_into_payments_attributes(massaged_params) # deprecated
-      end
       move_wallet_payment_source_id_into_payments_attributes(massaged_params)
       set_payment_parameters_amount(massaged_params, @order)
 

--- a/app/controllers/spree/checkout_controller.rb
+++ b/app/controllers/spree/checkout_controller.rb
@@ -17,7 +17,6 @@ module Spree
 
     before_action :associate_user
     before_action :check_authorization
-    before_action :apply_coupon_code
 
     before_action :setup_for_current_state, only: [:edit, :update]
 
@@ -165,24 +164,6 @@ module Spree
     # Provides a route to redirect after order completion
     def completion_route
       spree.order_path(@order)
-    end
-
-    def apply_coupon_code
-      if update_params[:coupon_code].present?
-        Spree::Deprecation.warn('This endpoint is deprecated. Please use `Spree::CouponCodesController#create` endpoint instead.')
-        @order.coupon_code = update_params[:coupon_code]
-
-        handler = PromotionHandler::Coupon.new(@order).apply
-
-        if handler.error.present?
-          flash.now[:error] = handler.error
-        elsif handler.success
-          flash[:success] = handler.success
-        end
-
-        setup_for_current_state
-        respond_with(@order) { |format| format.html { render :edit } } && return
-      end
     end
 
     def setup_for_current_state

--- a/app/controllers/spree/checkout_controller.rb
+++ b/app/controllers/spree/checkout_controller.rb
@@ -196,14 +196,6 @@ module Spree
         @wallet_payment_sources = try_spree_current_user.wallet.wallet_payment_sources
         @default_wallet_payment_source = @wallet_payment_sources.detect(&:default) ||
                                          @wallet_payment_sources.first
-
-        @payment_sources = Spree::DeprecatedInstanceVariableProxy.new(
-          self,
-          :deprecated_payment_sources,
-          :@payment_sources,
-          Spree::Deprecation,
-          "Please, do not use @payment_sources anymore, use @wallet_payment_sources instead."
-        )
       end
     end
 
@@ -232,23 +224,6 @@ module Spree
           redirect_to spree.checkout_state_path(@order.state)
         end
       end
-    end
-
-    # This method returns payment sources of the current user. It is no more
-    # used into our frontend. We used to assign the content of this method
-    # into an ivar (@payment_sources) into the checkout payment step. This
-    # method is here only to be able to deprecate this ivar and will be removed.
-    #
-    # DO NOT USE THIS METHOD!
-    #
-    # @return [Array<Spree::PaymentSource>] Payment sources connected to
-    #   current user wallet.
-    # @deprecated This method has been added to deprecate @payment_sources
-    #   ivar and will be removed. Use @wallet_payment_sources instead.
-    def deprecated_payment_sources
-      try_spree_current_user.wallet.wallet_payment_sources
-        .map(&:payment_source)
-        .select { |ps| ps.is_a?(Spree::CreditCard) }
     end
   end
 end

--- a/app/controllers/spree/orders_controller.rb
+++ b/app/controllers/spree/orders_controller.rb
@@ -10,7 +10,6 @@ module Spree
     before_action :assign_order, only: :update
     # note: do not lock the #edit action because that's where we redirect when we fail to acquire a lock
     around_action :lock_order, only: :update
-    before_action :apply_coupon_code, only: :update
     skip_before_action :verify_authenticity_token, only: [:populate]
 
     def show
@@ -121,22 +120,6 @@ module Spree
       unless @order
         flash[:error] = t('spree.order_not_found')
         redirect_to(root_path) && return
-      end
-    end
-
-    def apply_coupon_code
-      if order_params[:coupon_code].present?
-        Spree::Deprecation.warn('This endpoint is deprecated. Please use `Spree::CouponCodesController#create` endpoint instead.')
-        @order.coupon_code = order_params[:coupon_code]
-
-        handler = PromotionHandler::Coupon.new(@order).apply
-
-        if handler.error.present?
-          flash.now[:error] = handler.error
-          respond_with(@order) { |format| format.html { render :edit } } && return
-        elsif handler.success
-          flash[:success] = handler.success
-        end
       end
     end
   end

--- a/spec/controllers/spree/checkout_controller_spec.rb
+++ b/spec/controllers/spree/checkout_controller_spec.rb
@@ -532,50 +532,5 @@ describe Spree::CheckoutController, type: :controller do
         expect(response).to redirect_to(spree.checkout_state_path('confirm'))
       end
     end
-
-    context "when coupon code is applied" do
-      let(:promotion_handler) { instance_double('Spree::PromotionHandler::Coupon', error: nil, success: 'Coupon Applied!') }
-
-      it "continues checkout flow normally" do
-        expect(Spree::Deprecation).to receive(:warn)
-
-        expect(Spree::PromotionHandler::Coupon)
-          .to receive_message_chain(:new, :apply)
-          .and_return(promotion_handler)
-
-        put :update, params: { state: order.state, order: { coupon_code: coupon_code } }
-
-        expect(response).to render_template :edit
-        expect(flash.now[:success]).to eq('Coupon Applied!')
-      end
-
-      context "when coupon code is not applied" do
-        let(:promotion_handler) { instance_double('Spree::PromotionHandler::Coupon', error: 'Some error', success: false) }
-
-        it "setups the current step correctly before rendering" do
-          expect(Spree::Deprecation).to receive(:warn)
-
-          expect(Spree::PromotionHandler::Coupon)
-            .to receive_message_chain(:new, :apply)
-            .and_return(promotion_handler)
-          expect(controller).to receive(:setup_for_current_state)
-
-          put :update, params: { state: order.state, order: { coupon_code: coupon_code } }
-        end
-
-        it "render cart with coupon error" do
-          expect(Spree::Deprecation).to receive(:warn)
-
-          expect(Spree::PromotionHandler::Coupon)
-            .to receive_message_chain(:new, :apply)
-            .and_return(promotion_handler)
-
-          put :update, params: { state: order.state, order: { coupon_code: coupon_code } }
-
-          expect(response).to render_template :edit
-          expect(flash.now[:error]).to eq('Some error')
-        end
-      end
-    end
   end
 end

--- a/spec/controllers/spree/orders_controller_spec.rb
+++ b/spec/controllers/spree/orders_controller_spec.rb
@@ -169,40 +169,6 @@ describe Spree::OrdersController, type: :controller do
               expect(response).to redirect_to(spree.cart_path)
             end
           end
-
-          context "when coupon code is applied" do
-            let(:promotion_handler) { instance_double('Spree::PromotionHandler::Coupon', error: nil, success: 'Coupon Applied!') }
-
-            it "continues checkout flow normally" do
-              expect(Spree::Deprecation).to receive(:warn)
-
-              expect(Spree::PromotionHandler::Coupon)
-                .to receive_message_chain(:new, :apply)
-                .and_return(promotion_handler)
-
-              put :update, params: { state: order.state, order: { coupon_code: coupon_code } }
-
-              expect(response).to redirect_to(spree.cart_path)
-              expect(flash.now[:success]).to eq('Coupon Applied!')
-            end
-
-            context "when coupon code is not applied" do
-              let(:promotion_handler) { instance_double('Spree::PromotionHandler::Coupon', error: 'Some error', success: false) }
-
-              it "render cart with coupon error" do
-                expect(Spree::Deprecation).to receive(:warn)
-
-                expect(Spree::PromotionHandler::Coupon)
-                  .to receive_message_chain(:new, :apply)
-                  .and_return(promotion_handler)
-
-                put :update, params: { state: order.state, order: { coupon_code: coupon_code } }
-
-                expect(response).to render_template :edit
-                expect(flash.now[:error]).to eq('Some error')
-              end
-            end
-          end
         end
       end
     end


### PR DESCRIPTION
## Description

Removes all the code that is generating deprecation warning for how uses unsupported things with this engine.

## Motivation and Context

There's no reason to keep these warnings active, since this is a new gem, we won't have people upgrading from some old versions.

Closes #20 

## How Has This Been Tested?

RSpec should still be green since we are not using this code

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
