### PR TITLE
Add a solidus compare script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,12 +20,29 @@ jobs:
       - checkout
       - solidusio_extensions/run-tests-solidus-master
       - solidusio_extensions/store-test-results
+  solidus-compare:
+    docker:
+      - image: circleci/ruby:latest
+    steps:
+      - checkout
+      - run:
+          name: Prepare compare diff
+          command: bin/solidus_compare > /tmp/solidus_compare_results.diff
+      - store_artifacts:
+          path: /tmp/solidus_compare_results.diff
+          destination: solidus_compare_results.diff
+      - run:
+          name: Prepare test results
+          command: mkdir -p /tmp/test_results && bin/solidus_compare -r > /tmp/test_results/results.xml
+      - store_test_results:
+          path: /tmp/test_results
 
 workflows:
   "Run specs on supported Solidus versions":
     jobs:
       - run-specs-with-postgres
       - run-specs-with-mysql
+      - solidus-compare
   "Weekly run specs against master":
     triggers:
       - schedule:
@@ -37,3 +54,4 @@ workflows:
     jobs:
       - run-specs-with-postgres
       - run-specs-with-mysql
+      - solidus-compare

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
           destination: solidus_compare_results.diff
       - run:
           name: Prepare test results
-          command: mkdir -p /tmp/test_results && bin/solidus_compare -r > /tmp/test_results/results.xml
+          command: mkdir -p /tmp/test_results && bin/solidus_compare -s > /tmp/test_results/results.xml
       - store_test_results:
           path: /tmp/test_results
 

--- a/bin/solidus_compare
+++ b/bin/solidus_compare
@@ -8,17 +8,6 @@ require 'time'
 require 'yaml'
 require 'zlib'
 
-PROJECT_PATHS = [
-  'app/controllers',
-  'app/helpers',
-]
-PROJECT_BRANCH = 'master'
-
-SOURCE_REPO = 'https://github.com/solidusio/solidus.git'
-SOURCE_NAME = 'solidus'
-SOURCE_BRANCH = 'master'
-SOURCE_BASE_PATH = 'frontend/'
-
 CONFIG_PATH = 'config/solidus_compare.yml'
 
 @config = {}
@@ -35,8 +24,6 @@ end
 # ---------------------------------------------------------------------------- #
 
 def generate_comparison(report)
-  @config = YAML.load_file(CONFIG_PATH).deep_symbolize_keys if File.exists?(CONFIG_PATH)
-  @config[:ignore] ||= []
   report.each do |data|
     conf = @config[:ignore].find { |cfg| cfg[:path] == data[:path] }
     diffs = conf ? ( conf[:diffs] || [] ) : []
@@ -65,12 +52,23 @@ def generate_summary(report)
   puts output
 end
 
+def load_config
+  @config = YAML.load_file(CONFIG_PATH).deep_symbolize_keys if File.exists?(CONFIG_PATH)
+  @config[:ignore] ||= []
+  @config[:project_paths] ||= []
+  @config[:project_branch] ||= 'master'
+  @config[:source_repo] ||= 'https://github.com/solidusio/solidus.git'
+  @config[:source_name] ||= 'solidus'
+  @config[:source_branch] ||= 'master'
+  @config[:source_base_path] ||= 'frontend/'
+end
+
 def solidus_compare
-  report = PROJECT_PATHS.map do |path|
+  report = @config[:project_paths].map do |path|
     extra = ''
     extra += ' --compact-summary' if @cmd_options[:summary]
-    remote_source = "remotes/#{SOURCE_NAME}/#{SOURCE_BRANCH}:#{SOURCE_BASE_PATH}#{path}"
-    result = `git diff #{PROJECT_BRANCH}:#{path} #{remote_source}#{extra}`
+    remote_source = "remotes/#{@config[:source_name]}/#{@config[:source_branch]}:#{@config[:source_base_path]}#{path}"
+    result = `git diff #{@config[:project_branch]}:#{path} #{remote_source}#{extra}`
     puts("error with git diff #{path}") & exit if $?.exitstatus != 0
 
     if @cmd_options[:summary]
@@ -112,8 +110,8 @@ def update_ignore(report)
 end
 
 def update_source
-  if `git remote`.split("\n").none? SOURCE_NAME
-    `git remote add -f #{SOURCE_NAME} #{SOURCE_REPO}`
+  if `git remote`.split("\n").none? @config[:source_name]
+    `git remote add -f #{@config[:source_name]} #{@config[:source_repo]}`
     puts('error with git remote add') & exit if $?.exitstatus != 0
   end
 
@@ -123,5 +121,6 @@ end
 
 # ---------------------------------------------------------------------------- #
 
+load_config
 update_source
 solidus_compare

--- a/bin/solidus_compare
+++ b/bin/solidus_compare
@@ -2,12 +2,17 @@
 
 # frozen_string_literal: true
 
+require 'json'
+require 'time'
+
 PATHS = [
   'app/controllers',
   'app/helpers',
 ]
 REMOTE_REPO = 'https://github.com/solidusio/solidus.git'
 REMOTE_SOURCE = 'solidus'
+
+options = ARGV.any? && ARGV[0] == '-r' ? ' --name-only' : nil
 
 if `git remote`.split("\n").none? REMOTE_SOURCE
   `git remote add -f #{REMOTE_SOURCE} #{REMOTE_REPO}`
@@ -18,18 +23,34 @@ if `git remote`.split("\n").none? REMOTE_SOURCE
 end
 
 diff = PATHS.map do |path|
-  list = `git diff master:#{path} remotes/#{REMOTE_SOURCE}/master:frontend/#{path} --name-only`
+  list = `git diff master:#{path} remotes/#{REMOTE_SOURCE}/master:frontend/#{path}#{options}`
   puts("error with git diff #{path}") & exit if $?.exitstatus != 0
 
   next if list.empty?
 
-  puts "\n> #{path} changed files"
-  puts list
-  path
+  puts list unless options
+  {
+    id: path,
+    description: "Compared: #{path}",
+    file_path: path,
+    diff: list,
+    status: :failed
+  }
 end.compact
 
-if diff.any?
-  path = diff.first
-  cmd = "git diff master:#{path} remotes/#{REMOTE_SOURCE}/master:frontend/#{path}"
-  puts "\n#{cmd}\n  to check the changes"
+if options
+  testcases = diff.map do |testcase|
+    <<~EOS
+    <testcase name="Changes detected in #{testcase[:file_path]}" file="#{testcase[:file_path]}" time="0">
+      <failure>#{testcase[:diff]}</failure>
+    </testcase>
+    EOS
+  end.join("\n")
+  output = <<~EOS
+    <?xml version="1.0" encoding="UTF-8"?>
+    <testsuite name="solidus_compare" tests="#{PATHS.size}" skipped="0" failures="#{diff.size}" errors="#{diff.size}" time="1" timestamp="#{Time.now.iso8601}">
+    #{testcases}
+    </testsuite>
+  EOS
+  puts output
 end

--- a/bin/solidus_compare
+++ b/bin/solidus_compare
@@ -2,55 +2,126 @@
 
 # frozen_string_literal: true
 
+require 'active_support/core_ext/hash/keys'
 require 'json'
 require 'time'
+require 'yaml'
+require 'zlib'
 
-PATHS = [
+PROJECT_PATHS = [
   'app/controllers',
   'app/helpers',
 ]
-REMOTE_REPO = 'https://github.com/solidusio/solidus.git'
-REMOTE_SOURCE = 'solidus'
+PROJECT_BRANCH = 'master'
 
-options = ARGV.any? && ARGV[0] == '-r' ? ' --name-only' : nil
+SOURCE_REPO = 'https://github.com/solidusio/solidus.git'
+SOURCE_NAME = 'solidus'
+SOURCE_BRANCH = 'master'
+SOURCE_BASE_PATH = 'frontend/'
 
-if `git remote`.split("\n").none? REMOTE_SOURCE
-  `git remote add -f #{REMOTE_SOURCE} #{REMOTE_REPO}`
-  puts('error with git remote add') & exit if $?.exitstatus != 0
+CONFIG_PATH = 'config/solidus_compare.yml'
 
-  `git remote update`
-  puts('error with git remote update') & exit if $?.exitstatus != 0
+@config = {}
+@cmd_options = {}
+ARGV.each do |arg|
+  case arg
+  when '-s', '--summary'
+    @cmd_options[:summary] = true
+  when '-u', '--update-ignore'
+    @cmd_options[:update] = true
+  end
 end
 
-diff = PATHS.map do |path|
-  list = `git diff master:#{path} remotes/#{REMOTE_SOURCE}/master:frontend/#{path}#{options}`
-  puts("error with git diff #{path}") & exit if $?.exitstatus != 0
+# ---------------------------------------------------------------------------- #
 
-  next if list.empty?
+def generate_comparison(report)
+  @config = YAML.load_file(CONFIG_PATH).deep_symbolize_keys if File.exists?(CONFIG_PATH)
+  @config[:ignore] ||= []
+  report.each do |data|
+    conf = @config[:ignore].find { |cfg| cfg[:path] == data[:path] }
+    diffs = conf ? ( conf[:diffs] || [] ) : []
+    data[:diffs].each do |result|
+      next if diffs.find { |diff| diff[:hash] == result[:hash] }
 
-  puts list unless options
-  {
-    id: path,
-    description: "Compared: #{path}",
-    file_path: path,
-    diff: list,
-    status: :failed
-  }
-end.compact
+      puts result[:diff]
+    end
+  end
+  update_ignore(report) if @cmd_options[:update]
+end
 
-if options
-  testcases = diff.map do |testcase|
-    <<~EOS
-    <testcase name="Changes detected in #{testcase[:file_path]}" file="#{testcase[:file_path]}" time="0">
-      <failure>#{testcase[:diff]}</failure>
-    </testcase>
-    EOS
+def generate_summary(report)
+  testcases = report.map do |testcase|
+    name = testcase[:status] == :failed ? 'Changes detected ' : 'No changes '
+    name += "in #{testcase[:file_path]}"
+    "<testcase name=\"#{name}\" file=\"#{testcase[:file_path]}\" time=\"0\">#{testcase[:failure]}</testcase>"
   end.join("\n")
+  failures = report.count { |testcase| testcase[:status] == :failed }
   output = <<~EOS
     <?xml version="1.0" encoding="UTF-8"?>
-    <testsuite name="solidus_compare" tests="#{PATHS.size}" skipped="0" failures="#{diff.size}" errors="#{diff.size}" time="1" timestamp="#{Time.now.iso8601}">
+    <testsuite name="solidus_compare" tests="#{report.size}" skipped="0" failures="#{failures}" errors="#{failures}" time="1" timestamp="#{Time.now.iso8601}">
     #{testcases}
     </testsuite>
   EOS
   puts output
 end
+
+def solidus_compare
+  report = PROJECT_PATHS.map do |path|
+    extra = ''
+    extra += ' --compact-summary' if @cmd_options[:summary]
+    remote_source = "remotes/#{SOURCE_NAME}/#{SOURCE_BRANCH}:#{SOURCE_BASE_PATH}#{path}"
+    result = `git diff #{PROJECT_BRANCH}:#{path} #{remote_source}#{extra}`
+    puts("error with git diff #{path}") & exit if $?.exitstatus != 0
+
+    if @cmd_options[:summary]
+      {
+        path: path,
+        description: "Compared: #{path}",
+        file_path: path,
+        failure: result.empty? ? '' : "<failure>#{result}</failure>",
+        status: result.empty? ? :success : :failed
+      }
+    else
+      diffs = result.split(/diff --git /)[1..]
+      next unless diffs
+
+      {
+        path: path,
+        diffs: diffs.map do |diff|
+          {
+            hash: Zlib::crc32(diff),
+            file: diff.match(/a\/([^\s]+)/)&.send(:[], 1),
+            diff: 'diff --git ' + diff
+          }
+        end
+      }
+  end
+  end.compact
+
+  @cmd_options[:summary] ? generate_summary(report) : generate_comparison(report)
+end
+
+def update_ignore(report)
+  report.each do |data|
+    data[:diffs].each do |result|
+      result.delete(:diff)
+    end
+  end.compact
+  @config[:ignore] = report
+  File.open(CONFIG_PATH, 'w') { |f| f.puts(@config.deep_stringify_keys.to_yaml) }
+end
+
+def update_source
+  if `git remote`.split("\n").none? SOURCE_NAME
+    `git remote add -f #{SOURCE_NAME} #{SOURCE_REPO}`
+    puts('error with git remote add') & exit if $?.exitstatus != 0
+  end
+
+  `git remote update > /dev/null 2>&1`
+  puts('error with git remote update') & exit if $?.exitstatus != 0
+end
+
+# ---------------------------------------------------------------------------- #
+
+update_source
+solidus_compare

--- a/bin/solidus_compare
+++ b/bin/solidus_compare
@@ -28,7 +28,14 @@ def generate_comparison(report)
     conf = @config['ignore'].find { |cfg| cfg['path'] == data['path'] }
     diffs = conf ? ( conf['diffs'] || [] ) : []
     data['diffs'].each do |result|
-      next if diffs.find { |diff| diff['hash'] == result['hash'] }
+      info = diffs.find { |diff| diff['file'] == result['file'] } || {}
+      if info['skip']
+        result['skip'] = true
+        result.delete 'hash'
+        next
+      elsif info['hash'] == result['hash']
+        next
+      end
 
       puts result['diff']
     end
@@ -43,7 +50,8 @@ def generate_summary(report)
     conf = @config['ignore'].find { |cfg| cfg['path'] == path }
     diffs = conf ? ( conf['diffs'] || [] ) : []
     data['diffs'].each do |result|
-      next if diffs.find { |diff| diff['hash'] == result['hash'] }
+      info = diffs.find { |diff| diff['file'] == result['file'] } || {}
+      next if info['skip'] || info['hash'] == result['hash']
 
       (summary[path] ||= {})[result['hash']] = result['file']
     end

--- a/bin/solidus_compare
+++ b/bin/solidus_compare
@@ -3,6 +3,7 @@
 # frozen_string_literal: true
 
 require 'json'
+require 'pathname'
 require 'time'
 require 'yaml'
 require 'zlib'
@@ -36,19 +37,36 @@ def generate_comparison(report)
 end
 
 def generate_summary(report)
-  testcases = report.map do |testcase|
-    name = testcase['status'] == :failed ? 'Changes detected ' : 'No changes '
-    name += "in #{testcase['file_path']}"
-    "<testcase name=\"#{name}\" file=\"#{testcase['file_path']}\" time=\"0\">#{testcase['failure']}</testcase>"
+  summary = {}
+  report.each do |data|
+    path = data['path']
+    conf = @config['ignore'].find { |cfg| cfg['path'] == path }
+    diffs = conf ? ( conf['diffs'] || [] ) : []
+    data['diffs'].each do |result|
+      next if diffs.find { |diff| diff['hash'] == result['hash'] }
+
+      (summary[path] ||= {})[result['hash']] = result['file']
+    end
+  end
+
+  count = 0
+  testcases = summary.map do |file_path, value|
+    value.map do |hash, file|
+      count += 1
+      full_path = Pathname.new(file_path).join(file).to_s
+      "<testcase name=\"#{file}\" file=\"#{full_path}\" time=\"0\"><failure>hash: #{hash}\nfile: #{file}</failure></testcase>"
+    end
   end.join("\n")
-  failures = report.count { |testcase| testcase['status'] == :failed }
+
   output = <<~EOS
     <?xml version="1.0" encoding="UTF-8"?>
-    <testsuite name="solidus_compare" tests="#{report.size}" skipped="0" failures="#{failures}" errors="#{failures}" time="1" timestamp="#{Time.now.iso8601}">
+    <testsuite name="solidus_compare" tests="#{count}" skipped="0" failures="#{count}" errors="#{count}" time="1" timestamp="#{Time.now.iso8601}">
     #{testcases}
     </testsuite>
   EOS
   puts output
+
+  exit 1 if count.positive?
 end
 
 def load_config
@@ -65,35 +83,25 @@ end
 
 def solidus_compare
   report = @config['project_paths'].map do |path|
-    extra = ''
-    extra += ' --compact-summary' if @cmd_options[:summary]
     remote_source = "remotes/#{@config['source_name']}/#{@config['source_branch']}:#{@config['source_base_path']}#{path}"
-    result = `git diff #{@config['project_branch']}:#{path} #{remote_source}#{extra}`
+    result = `git diff #{@config['project_branch']}:#{path} #{remote_source}`
     puts("error with git diff #{path}") & exit if $?.exitstatus != 0
 
-    if @cmd_options[:summary]
-      {
-        'path' => path,
-        'description' => "Compared: #{path}",
-        'file_path' => path,
-        'failure' => result.empty? ? '' : "<failure>#{result}</failure>",
-        'status' => result.empty? ? :success : :failed
-      }
-    else
-      diffs = result.split(/diff --git /)[1..]
-      next unless diffs
+    diffs = result.split(/diff --git /)[1..]
+    next unless diffs
 
-      {
-        'path' => path,
-        'diffs' => diffs.map do |diff|
-          {
-            'hash' => Zlib::crc32(diff),
-            'file' => diff.match(/a\/([^\s]+)/)&.send(:[], 1),
-            'diff' => 'diff --git ' + diff
-          }
-        end
-      }
-  end
+    {
+      'path' => path,
+      'diffs' => diffs.map do |diff|
+        {
+          'hash' => Zlib::crc32(diff),
+          'file' => diff.match(/a\/([^\s]+)/)&.send(:[], 1),
+          'diff' => 'diff --git ' + diff
+        }
+      end
+    }
+
+    # end
   end.compact
 
   @cmd_options[:summary] ? generate_summary(report) : generate_comparison(report)

--- a/bin/solidus_compare
+++ b/bin/solidus_compare
@@ -82,7 +82,6 @@ def load_config
   @config ||= {}
   @config['ignore'] ||= []
   @config['project_paths'] ||= []
-  @config['project_branch'] ||= 'master'
   @config['source_repo'] ||= 'https://github.com/solidusio/solidus.git'
   @config['source_name'] ||= 'solidus'
   @config['source_branch'] ||= 'master'
@@ -91,8 +90,9 @@ end
 
 def solidus_compare
   report = @config['project_paths'].map do |path|
-    remote_source = "remotes/#{@config['source_name']}/#{@config['source_branch']}:#{@config['source_base_path']}#{path}"
-    result = `git diff #{@config['project_branch']}:#{path} #{remote_source}`
+    remote_source = "remotes/#{@config['source_name']}/#{@config['source_branch']}"
+    remote_path = "#{@config['source_base_path']}#{path}"
+    result = `git diff "#{remote_source}" -- "#{remote_path}" "#{path}"`
     puts("error with git diff #{path}") & exit if $?.exitstatus != 0
 
     diffs = result.split(/diff --git /)[1..]
@@ -101,12 +101,14 @@ def solidus_compare
     {
       'path' => path,
       'diffs' => diffs.map do |diff|
+        next if diff.include? 'similarity index 100%'
+
         {
           'hash' => Zlib::crc32(diff),
           'file' => diff.match(/a\/([^\s]+)/)&.send(:[], 1),
           'diff' => 'diff --git ' + diff
         }
-      end
+      end.compact
     }
 
     # end

--- a/bin/solidus_compare
+++ b/bin/solidus_compare
@@ -2,7 +2,6 @@
 
 # frozen_string_literal: true
 
-require 'active_support/core_ext/hash/keys'
 require 'json'
 require 'time'
 require 'yaml'
@@ -25,12 +24,12 @@ end
 
 def generate_comparison(report)
   report.each do |data|
-    conf = @config[:ignore].find { |cfg| cfg[:path] == data[:path] }
-    diffs = conf ? ( conf[:diffs] || [] ) : []
-    data[:diffs].each do |result|
-      next if diffs.find { |diff| diff[:hash] == result[:hash] }
+    conf = @config['ignore'].find { |cfg| cfg['path'] == data['path'] }
+    diffs = conf ? ( conf['diffs'] || [] ) : []
+    data['diffs'].each do |result|
+      next if diffs.find { |diff| diff['hash'] == result['hash'] }
 
-      puts result[:diff]
+      puts result['diff']
     end
   end
   update_ignore(report) if @cmd_options[:update]
@@ -38,11 +37,11 @@ end
 
 def generate_summary(report)
   testcases = report.map do |testcase|
-    name = testcase[:status] == :failed ? 'Changes detected ' : 'No changes '
-    name += "in #{testcase[:file_path]}"
-    "<testcase name=\"#{name}\" file=\"#{testcase[:file_path]}\" time=\"0\">#{testcase[:failure]}</testcase>"
+    name = testcase['status'] == :failed ? 'Changes detected ' : 'No changes '
+    name += "in #{testcase['file_path']}"
+    "<testcase name=\"#{name}\" file=\"#{testcase['file_path']}\" time=\"0\">#{testcase['failure']}</testcase>"
   end.join("\n")
-  failures = report.count { |testcase| testcase[:status] == :failed }
+  failures = report.count { |testcase| testcase['status'] == :failed }
   output = <<~EOS
     <?xml version="1.0" encoding="UTF-8"?>
     <testsuite name="solidus_compare" tests="#{report.size}" skipped="0" failures="#{failures}" errors="#{failures}" time="1" timestamp="#{Time.now.iso8601}">
@@ -53,43 +52,44 @@ def generate_summary(report)
 end
 
 def load_config
-  @config = YAML.load_file(CONFIG_PATH).deep_symbolize_keys if File.exists?(CONFIG_PATH)
-  @config[:ignore] ||= []
-  @config[:project_paths] ||= []
-  @config[:project_branch] ||= 'master'
-  @config[:source_repo] ||= 'https://github.com/solidusio/solidus.git'
-  @config[:source_name] ||= 'solidus'
-  @config[:source_branch] ||= 'master'
-  @config[:source_base_path] ||= 'frontend/'
+  @config = YAML.load_file(CONFIG_PATH) if File.exists?(CONFIG_PATH)
+  @config ||= {}
+  @config['ignore'] ||= []
+  @config['project_paths'] ||= []
+  @config['project_branch'] ||= 'master'
+  @config['source_repo'] ||= 'https://github.com/solidusio/solidus.git'
+  @config['source_name'] ||= 'solidus'
+  @config['source_branch'] ||= 'master'
+  @config['source_base_path'] ||= 'frontend/'
 end
 
 def solidus_compare
-  report = @config[:project_paths].map do |path|
+  report = @config['project_paths'].map do |path|
     extra = ''
     extra += ' --compact-summary' if @cmd_options[:summary]
-    remote_source = "remotes/#{@config[:source_name]}/#{@config[:source_branch]}:#{@config[:source_base_path]}#{path}"
-    result = `git diff #{@config[:project_branch]}:#{path} #{remote_source}#{extra}`
+    remote_source = "remotes/#{@config['source_name']}/#{@config['source_branch']}:#{@config['source_base_path']}#{path}"
+    result = `git diff #{@config['project_branch']}:#{path} #{remote_source}#{extra}`
     puts("error with git diff #{path}") & exit if $?.exitstatus != 0
 
     if @cmd_options[:summary]
       {
-        path: path,
-        description: "Compared: #{path}",
-        file_path: path,
-        failure: result.empty? ? '' : "<failure>#{result}</failure>",
-        status: result.empty? ? :success : :failed
+        'path' => path,
+        'description' => "Compared: #{path}",
+        'file_path' => path,
+        'failure' => result.empty? ? '' : "<failure>#{result}</failure>",
+        'status' => result.empty? ? :success : :failed
       }
     else
       diffs = result.split(/diff --git /)[1..]
       next unless diffs
 
       {
-        path: path,
-        diffs: diffs.map do |diff|
+        'path' => path,
+        'diffs' => diffs.map do |diff|
           {
-            hash: Zlib::crc32(diff),
-            file: diff.match(/a\/([^\s]+)/)&.send(:[], 1),
-            diff: 'diff --git ' + diff
+            'hash' => Zlib::crc32(diff),
+            'file' => diff.match(/a\/([^\s]+)/)&.send(:[], 1),
+            'diff' => 'diff --git ' + diff
           }
         end
       }
@@ -101,17 +101,17 @@ end
 
 def update_ignore(report)
   report.each do |data|
-    data[:diffs].each do |result|
-      result.delete(:diff)
+    data['diffs'].each do |result|
+      result.delete('diff')
     end
   end.compact
-  @config[:ignore] = report
-  File.open(CONFIG_PATH, 'w') { |f| f.puts(@config.deep_stringify_keys.to_yaml) }
+  @config['ignore'] = report
+  File.open(CONFIG_PATH, 'w') { |f| f.puts(@config.to_yaml) }
 end
 
 def update_source
-  if `git remote`.split("\n").none? @config[:source_name]
-    `git remote add -f #{@config[:source_name]} #{@config[:source_repo]}`
+  if `git remote`.split("\n").none? @config['source_name']
+    `git remote add -f #{@config['source_name']} #{@config['source_repo']}`
     puts('error with git remote add') & exit if $?.exitstatus != 0
   end
 

--- a/config/solidus_compare.yml
+++ b/config/solidus_compare.yml
@@ -1,4 +1,12 @@
 ---
+project_paths:
+- app/controllers
+- app/helpers
+project_branch: master
+source_repo: https://github.com/solidusio/solidus.git
+source_name: solidus
+source_branch: master
+source_base_path: frontend/
 ignore:
 - path: app/controllers
   diffs:

--- a/config/solidus_compare.yml
+++ b/config/solidus_compare.yml
@@ -1,0 +1,8 @@
+---
+ignore:
+- path: app/controllers
+  diffs:
+  - hash: 3804005517
+    file: concerns/solidus_starter_frontend/auth_views.rb
+  - hash: 3208037425
+    file: concerns/solidus_starter_frontend/taxonomies.rb

--- a/config/solidus_compare.yml
+++ b/config/solidus_compare.yml
@@ -10,7 +10,7 @@ source_base_path: frontend/
 ignore:
 - path: app/controllers
   diffs:
-  - hash: 3804005517
-    file: concerns/solidus_starter_frontend/auth_views.rb
-  - hash: 3208037425
-    file: concerns/solidus_starter_frontend/taxonomies.rb
+  - file: concerns/solidus_starter_frontend/auth_views.rb
+    skip: true
+  - file: concerns/solidus_starter_frontend/taxonomies.rb
+    skip: true

--- a/config/solidus_compare.yml
+++ b/config/solidus_compare.yml
@@ -2,7 +2,6 @@
 project_paths:
 - app/controllers
 - app/helpers
-project_branch: master
 source_repo: https://github.com/solidusio/solidus.git
 source_name: solidus
 source_branch: master
@@ -10,7 +9,7 @@ source_base_path: frontend/
 ignore:
 - path: app/controllers
   diffs:
-  - file: concerns/solidus_starter_frontend/auth_views.rb
-    skip: true
-  - file: concerns/solidus_starter_frontend/taxonomies.rb
-    skip: true
+  - skip: true
+    file: app/controllers/concerns/solidus_starter_frontend/auth_views.rb
+  - skip: true
+    file: app/controllers/concerns/solidus_starter_frontend/taxonomies.rb


### PR DESCRIPTION
It will allow us to monitor the changes on a Solidus project path.

## Usage
- To list the changes in diff format: `bin/solidus_compare`
- Apply the required changes
- To update the ignores list (ignore key in _config/solidus_compare.yml_): `bin/solidus_compare -u`

## Description
To keep our code in sync with the latest changes on Solidus frontend we can use this tool to list what changed.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
