### PR TITLE
Fix Login Form

### DIFF
--- a/app/views/spree/components/auth/_forgot_form.html.erb
+++ b/app/views/spree/components/auth/_forgot_form.html.erb
@@ -9,7 +9,7 @@
       "spree/components/forms/inputs/text",
       id: :spree_user_email,
       label: I18n.t("spree.email"),
-      name: :email,
+      name: 'spree_user[email]',
       placeholder: "name@example.com",
       type: :email
     ) %>

--- a/app/views/spree/components/auth/_guest_form.html.erb
+++ b/app/views/spree/components/auth/_guest_form.html.erb
@@ -6,13 +6,13 @@
   url = update_checkout_registration_path
 %>
 
-<%= form_for @order, as: :spree_user, url: url, method: :put, html: html do |f| %>
+<%= form_for @order, url: url, method: :put, html: html do |f| %>
   <div class="auth-form__input-wrapper">
     <%= render(
       "spree/components/forms/inputs/text",
       id: :spree_user_email,
       label: I18n.t("spree.email"),
-      name: :email,
+      name: 'order[email]',
       placeholder: "name@example.com",
       type: :email
     ) %>

--- a/app/views/spree/components/auth/_login_form.html.erb
+++ b/app/views/spree/components/auth/_login_form.html.erb
@@ -9,7 +9,7 @@
       "spree/components/forms/inputs/text",
       id: :spree_user_email,
       label: I18n.t("spree.email"),
-      name: :email,
+      name: 'spree_user[email]',
       placeholder: "name@example.com",
       type: :email
     ) %>
@@ -19,7 +19,7 @@
       "spree/components/forms/inputs/text",
       id: :spree_user_password,
       label: I18n.t("spree.password"),
-      name: :password,
+      name: 'spree_user[password]',
       placeholder: "p455w0rd",
       type: :password
     ) %>

--- a/app/views/spree/components/auth/_signup_form.html.erb
+++ b/app/views/spree/components/auth/_signup_form.html.erb
@@ -9,7 +9,7 @@
       "spree/components/forms/inputs/text",
       id: :spree_user_email,
       label: I18n.t("spree.email"),
-      name: :email,
+      name: 'spree_user[email]',
       placeholder: "name@example.com",
       type: :email
     ) %>
@@ -19,7 +19,7 @@
       "spree/components/forms/inputs/text",
       id: :spree_user_password,
       label: I18n.t("spree.password"),
-      name: :password,
+      name: 'spree_user[password]',
       placeholder: "p455w0rd",
       type: :password
     ) %>
@@ -29,7 +29,7 @@
       "spree/components/forms/inputs/text",
       id: :spree_user_password_confirmation,
       label: I18n.t("spree.confirm_password"),
-      name: :password_confirmation,
+      name: 'spree_user[password_confirmation]',
       placeholder: "p455w0rd",
       type: :password
     ) %>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Restore the following functionalities, passing the right form field name to the text input partial:
- login
- signup
- password reset
- guest checkout

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Having single form fields now refactored using generic partials, we must pass the exact form field name to the partial. The original view was using a form helper and the field name was generated by the form builder object. It was an oversight.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
