### PR TITLE
Fix gateway partial that uses non-existing `billing_name` method

### DIFF
--- a/app/views/spree/checkout/payment/_gateway.html.erb
+++ b/app/views/spree/checkout/payment/_gateway.html.erb
@@ -7,7 +7,7 @@
     id: "name_on_card_#{payment_method.id}",
     label: t('spree.name_on_card'),
     name: "#{param_prefix}[name]",
-    value: @order.billing_name
+    value: "#{@order.billing_firstname} #{@order.billing_lastname}"
   ) %>
 
   <%= render(

--- a/app/views/spree/checkout/payment/_gateway.html.erb
+++ b/app/views/spree/checkout/payment/_gateway.html.erb
@@ -7,7 +7,7 @@
     id: "name_on_card_#{payment_method.id}",
     label: t('spree.name_on_card'),
     name: "#{param_prefix}[name]",
-    value: "#{@order.billing_firstname} #{@order.billing_lastname}"
+    value: @order.try(:billing_name) || "#{@order.billing_firstname} #{@order.billing_lastname}"
   ) %>
 
   <%= render(


### PR DESCRIPTION
## Description

Use the two name methods available instead.

`billing_name` doesn't seem to be a valid method, at least on Solidus v2.10 (the one I'm using). 

## How Has This Been Tested?

The checkout is broken on a fresh install of this gem using Solidus v2.10.

- [ ] My change requires a change to the documentation.
- [X] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
