### PR TITLE
Add an install generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,32 +28,26 @@ exclude it and manually include all the other Solidus componenents.
 
 You need to replace:
 
-```
+```ruby
 gem 'solidus'
 ```
 
 with:
 
-```
+```ruby
 gem 'solidus_core'
 gem 'solidus_api'
 gem 'solidus_backend'
 gem 'solidus_sample'
-gem "solidus_starter_frontend"
 ```
 
-If Solidus was already installed, you have to run:
+Install our binary in the system: `gem install solidus_starter_frontend`
 
-```
-bundle
-bundle exec rails g solidus_starter_frontend:install
-```
+Execute our generator that will copy our component files in your project:
+`solidus_starter_frontend`
 
-and change all `Spree::Frontend::Config` in `SolidusStarterFrontend::Config`.
-
-If it's the first Solidus installation you need to run the Solidus install
-before `bundle exec rails g solidus_starter_frontend:install`.
-Please, take a look at the [Solidus README](https://github.com/solidusio/solidus#installation-options).
+If Solidus was already installed with solidus_frontend you will have to change
+all `Spree::Frontend::Config` in `SolidusStarterFrontend::Config`.
 
 ## Customization
 

--- a/README.md
+++ b/README.md
@@ -44,36 +44,10 @@ gem 'solidus_sample'
 Install our binary in the system: `gem install solidus_starter_frontend`
 
 Execute our generator that will copy our component files in your project:
-`solidus_starter_frontend`
+`solidus_starter_frontend`. Now you can start to customize your local views.
 
 If Solidus was already installed with solidus_frontend you will have to change
 all `Spree::Frontend::Config` in `SolidusStarterFrontend::Config`.
-
-## Customization
-
-In order to customize a view you should copy the file into your host app.
-Using Deface is not recommended as it provides lots of headaches while
-debugging and degrades your shops performance.
-
-Solidus provides a generator to help with copying the right view into your host
-app.
-
-Simply call the generator to copy all views into your host app:
-```bash
-$ bundle exec rails g solidus_starter_frontend:views:override
-```
-
-If you only want to copy certain views into your host app, you can provide the
-`--only` argument:
-```bash
-$ bundle exec rails g solidus_starter_frontend:views:override --only products/show
-```
-
-The argument to `--only` can also be a substring of the name of the view from
-the `app/views/spree` folder:
-```bash
-$ bundle exec rails g solidus_starter_frontend:views:override --only product
-```
 
 ## About
 

--- a/exe/solidus_starter_frontend
+++ b/exe/solidus_starter_frontend
@@ -1,0 +1,9 @@
+#!/usr/bin/env ruby
+
+# frozen_string_literal: true
+
+require 'active_support'
+require 'rails/generators'
+require 'solidus_starter_frontend'
+
+Rails::Generators.invoke('solidus_starter_frontend')

--- a/lib/generators/solidus_starter_frontend/solidus_starter_frontend_generator.rb
+++ b/lib/generators/solidus_starter_frontend/solidus_starter_frontend_generator.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class SolidusStarterFrontendGenerator < Rails::Generators::Base
+  source_root File.expand_path('../../..', __dir__)
+
+  def install
+    # Copy directories
+    directory 'app', 'app'
+    directory 'lib/views', 'lib/views'
+
+    # Copy files
+    copy_file 'lib/solidus_starter_frontend/config.rb', 'lib/solidus_starter_frontend/config.rb'
+    copy_file 'lib/solidus_starter_frontend_configuration.rb', 'lib/solidus_starter_frontend_configuration.rb'
+
+    # Routes
+    copy_file 'config/routes.rb', 'tmp/routes.rb'
+    prepend_file 'config/routes.rb', File.read('tmp/routes.rb')
+
+    # Gems
+    gem 'canonical-rails'
+    gem 'truncate_html'
+
+    # Text updates
+    append_file 'config/initializers/assets.rb', "Rails.application.config.assets.precompile += ['solidus_starter_frontend_manifest.js']"
+    append_file 'vendor/assets/javascripts/spree/frontend/all.js', "//= require spree/frontend/solidus_starter_frontend\n"
+    inject_into_file 'vendor/assets/stylesheets/spree/frontend/all.css', " *= require spree/frontend/solidus_starter_frontend\n", before: %r{\*/}, verbose: true
+    inject_into_file 'config/initializers/spree.rb', "require_relative Rails.root.join('lib/solidus_starter_frontend/config')\n", before: /Spree.config do/, verbose: true
+    gsub_file 'app/assets/stylesheets/application.css', '*= require_tree', '* OFF require_tree'
+  end
+end


### PR DESCRIPTION
## Description
Add an install generator.

## Install test procedure

- Build our gem: `gem build solidus_starter_frontend.gemspec`
- Install it in the system: `gem install solidus_starter_frontend-0.0.1.gem`
- Create a new Rails app using scaffolding:
`rails new solidus_test1 --skip-action-cable --skip-bootsnap --skip-coffee --skip-spring --skip-system-test --skip-test --skip-turbolinks`
- Add to the Gemfile:
```ruby
gem 'solidus_core'
gem 'solidus_api'
gem 'solidus_backend'
gem 'solidus_sample'
```
- Execute `bundle`
- Execute `bin/rails g spree:install`
- Execute `solidus_starter_frontend`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
