### PR TITLE
Remove 'All' link from categories taxons

### DIFF
--- a/app/views/spree/components/navigation/_categories.html.erb
+++ b/app/views/spree/components/navigation/_categories.html.erb
@@ -1,7 +1,6 @@
 <% categories = Spree::Taxonomy.includes(root: :children).first %>
 
 <nav class="categories">
-  <%= link_to 'All', products_path %>
   <% cache [I18n.locale, categories, @taxon] do %>
     <%= render(
       'spree/components/navigation/taxons_tree',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
ref: #67 

Just removes the `All` link from Categories Taxons inside the header


## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
