### PR TITLE
Restore locale selector as a component

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'solidus_core', github: 'solidusio/solidus', branch: branch
 gem 'solidus_api', github: 'solidusio/solidus', branch: branch
 gem 'solidus_backend', github: 'solidusio/solidus', branch: branch
 gem 'solidus_sample', github: 'solidusio/solidus', branch: branch
+gem 'solidus_i18n', github: 'solidusio/solidus_i18n', branch: branch
 
 # Needed to help Bundler figure out how to resolve dependencies,
 # otherwise it takes forever to resolve them.

--- a/app/assets/javascripts/spree/frontend/locale_selector.js
+++ b/app/assets/javascripts/spree/frontend/locale_selector.js
@@ -1,5 +1,7 @@
-$(function() {
-  $('#locale_selector select').change(function() {
-    this.form.submit();
+window.addEventListener('DOMContentLoaded', () => {
+  const localeSelector = document.querySelector('.locale-selector select');
+
+  localeSelector.addEventListener('change', (event) => {
+    event.target.form.submit();
   });
 });

--- a/app/assets/stylesheets/spree/frontend/components/navigation/_locale_selector.scss
+++ b/app/assets/stylesheets/spree/frontend/components/navigation/_locale_selector.scss
@@ -1,0 +1,21 @@
+.locale-selector {
+  margin: 3rem auto;
+  width: 20rem;
+
+  &__select-input {
+    position: relative;
+
+    select {
+      padding: 0 3rem 0 1rem;
+    }
+
+    &::after {
+      content: '\2304';
+      font-size: 2rem;
+      pointer-events: none;
+      position: absolute;
+      right: 1rem;
+      top: 1.6rem;
+    }
+  }
+}

--- a/app/assets/stylesheets/spree/frontend/screen.scss
+++ b/app/assets/stylesheets/spree/frontend/screen.scss
@@ -61,6 +61,7 @@
 @import "spree/frontend/components/navigation/categories";
 @import "spree/frontend/components/navigation/taxonomies";
 @import "spree/frontend/components/navigation/taxonomy";
+@import "spree/frontend/components/navigation/locale_selector";
 @import "spree/frontend/components/orders/address_overview";
 @import "spree/frontend/components/orders/coupon_codes";
 @import "spree/frontend/components/orders/line_items";

--- a/app/views/spree/components/forms/inputs/_select_input.html.erb
+++ b/app/views/spree/components/forms/inputs/_select_input.html.erb
@@ -6,10 +6,10 @@
   id = local_assigns.fetch(:id, nil)
   label = local_assigns.fetch(:label, false)
   selected = local_assigns.fetch(:selected, nil)
+  classes = local_assigns.fetch(:classes, [])
 
   # Classes
-  class_names = [base_class]
-  class_names = class_names.join(" ")
+  class_names = classes.push(base_class).join(" ")
 %>
 
 <div class="<%= class_names %>">

--- a/app/views/spree/components/layout/_footer.html.erb
+++ b/app/views/spree/components/layout/_footer.html.erb
@@ -2,4 +2,6 @@
   <p>
     <%= t 'spree.powered_by' %> <%= link_to 'Solidus', 'http://solidus.io/' %>
   </p>
+
+  <%= render 'spree/components/navigation/locale_selector' %>
 </footer>

--- a/app/views/spree/components/navigation/_locale_selector.html.erb
+++ b/app/views/spree/components/navigation/_locale_selector.html.erb
@@ -1,0 +1,25 @@
+<%
+  available_locales = current_store.available_locales.map do |locale|
+    [
+      I18n.t('spree.i18n.this_file_language',
+      locale: locale,
+      default: locale.to_s,
+      fallback: false), locale
+    ]
+  end.sort
+%>
+
+<% if available_locales.many? %>
+  <div class="locale-selector">
+    <%= form_tag spree.select_locale_path do %>
+      <%= render(
+        "spree/components/forms/inputs/select_input",
+        name: :switch_to_locale,
+        options: available_locales,
+        selected: I18n.locale,
+        label: I18n.t('spree.i18n.language'),
+        classes: ['locale-selector__select-input']
+      ) %>
+    <% end %>
+  </div>
+<% end %>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
ref: #72 
## Description
<!--- Describe your changes in detail -->
This pr restores the locale selector that has been missed during the views refactor.
I've moved the selector inside the footer, instead of restoring it in the header as it was in the original solidus_frontend.

## Screenshots (if appropriate):
![Untitled 2](https://user-images.githubusercontent.com/3853105/89059177-fe00ae00-d360-11ea-884b-4b16f17be003.png)



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
