### PR TITLE
Remove the use of CSS class names in JavaScript

### DIFF
--- a/app/assets/javascripts/spree/frontend/cart.js
+++ b/app/assets/javascripts/spree/frontend/cart.js
@@ -1,26 +1,26 @@
 window.addEventListener('DOMContentLoaded', () => {
-  const cartForm = document.getElementById('update-cart');
+  const cartForm = document.getElementById('update-cart')
 
   if (cartForm) {
-    const deleteButtons = cartForm.querySelectorAll('input.delete');
+    const deleteButtons = cartForm.querySelectorAll('[data-module="cart-item-remove"]')
 
-    deleteButtons.forEach(deleteButton => {
+    deleteButtons.forEach((deleteButton) => {
       deleteButton.addEventListener('click', () => {
-        const lineItem = deleteButton.parentNode.parentNode;
-        lineItem.querySelector('.cart-item__quantity input').setAttribute('value', 0);
-      });
-    });
+        const lineItem = deleteButton.parentNode.parentNode
+        lineItem.querySelector('[data-module="cart-item-quantity"] input').setAttribute('value', 0)
+      })
+    })
 
     cartForm.addEventListener('submit', () => {
-      document.getElementById('update-button').setAttribute('disabled', true);
-    });
+      document.getElementById('update-button').setAttribute('disabled', true)
+    })
   }
-});
+})
 
 Solidus.fetch_cart = (cartLinkUrl) => {
   fetch(cartLinkUrl || Solidus.pathFor('cart_link'))
-    .then(response => response.text())
-    .then(html => {
-      document.getElementById('link-to-cart').innerHTML = html;
-    });
-};
+    .then((response) => response.text())
+    .then((html) => {
+      document.getElementById('link-to-cart').innerHTML = html
+    })
+}

--- a/app/assets/javascripts/spree/frontend/locale_selector.js
+++ b/app/assets/javascripts/spree/frontend/locale_selector.js
@@ -1,7 +1,9 @@
 window.addEventListener('DOMContentLoaded', () => {
-  const localeSelector = document.querySelector('.locale-selector select');
+  const localeSelector = document.querySelector('.locale-selector select')
 
-  localeSelector.addEventListener('change', (event) => {
-    event.target.form.submit();
-  });
-});
+  if (localeSelector) {
+    localeSelector.addEventListener('change', (event) => {
+      event.target.form.submit()
+    })
+  }
+})

--- a/app/assets/javascripts/spree/frontend/locale_selector.js
+++ b/app/assets/javascripts/spree/frontend/locale_selector.js
@@ -1,5 +1,5 @@
 window.addEventListener('DOMContentLoaded', () => {
-  const localeSelector = document.querySelector('.locale-selector select')
+  const localeSelector = document.querySelector('[data-module="locale-selector"] select')
 
   if (localeSelector) {
     localeSelector.addEventListener('change', (event) => {

--- a/app/assets/javascripts/spree/frontend/product.js
+++ b/app/assets/javascripts/spree/frontend/product.js
@@ -1,21 +1,22 @@
 window.addEventListener('DOMContentLoaded', () => {
   function updateVariantPrice(variant) {
-    const variantPrice = variant.dataset.price;
+    const variantPrice = variant.dataset.price
+    const priceEl = document.querySelector('[data-module="product-price"]')
+
     if (variantPrice) {
-      document.querySelector('.price.selling').innerHTML = variantPrice;
+      priceEl.innerHTML = variantPrice
     }
-  };
-
-  const radios = document.querySelectorAll('#product-variants input[type="radio"]');
-
-  if (radios.length > 0) {
-    const selectedRadio = document
-      .querySelector('#product-variants input[type="radio"][checked="checked"]');
-
-    updateVariantPrice(selectedRadio);
   }
 
-  radios.forEach(radio => {
-    radio.addEventListener('click', () => updateVariantPrice(radio));
-  });
-});
+  const radios = document.querySelectorAll('#product-variants input[type="radio"]')
+
+  if (radios.length > 0) {
+    const selectedRadio = document.querySelector('#product-variants input[type="radio"][checked="checked"]')
+
+    updateVariantPrice(selectedRadio)
+  }
+
+  radios.forEach((radio) => {
+    radio.addEventListener('click', () => updateVariantPrice(radio))
+  })
+})

--- a/app/views/spree/components/cart/_cart_item.html.erb
+++ b/app/views/spree/components/cart/_cart_item.html.erb
@@ -25,7 +25,7 @@
       <%= line_item.single_money.to_html %>
     </div>
 
-    <div class="cart-item__quantity">
+    <div class="cart-item__quantity" data-module="cart-item-quantity">
       <%= render(
         'spree/components/forms/inputs/text',
         id: "order_line_items_attributes_#{item_form.options[:child_index]}_quantity",
@@ -43,9 +43,8 @@
     <div class="cart-item__remove">
       <%= submit_tag(
         'Remove',
-        class: 'delete',
         id: "delete_#{dom_id(line_item)}",
-        data: { disable_with: 'Remove' }
+        data: { disable_with: 'Remove', module: 'cart-item-remove' }
       ) %>
     </div>
   </article>

--- a/app/views/spree/components/navigation/_locale_selector.html.erb
+++ b/app/views/spree/components/navigation/_locale_selector.html.erb
@@ -10,7 +10,7 @@
 %>
 
 <% if available_locales.many? %>
-  <div class="locale-selector">
+  <div class="locale-selector" data-module="locale-selector">
     <%= form_tag spree.select_locale_path do %>
       <%= render(
         "spree/components/forms/inputs/select_input",

--- a/app/views/spree/components/products/_product-card.html.erb
+++ b/app/views/spree/components/products/_product-card.html.erb
@@ -25,7 +25,7 @@
       </header>
       <section class="product-card_price" itemprop="offers" itemscope itemtype="http://schema.org/Offer">
         <% if price = product.price_for(current_pricing_options) %>
-          <span class="price selling" itemprop="price" content="<%= price.to_d %>">
+          <span itemprop="price" content="<%= price.to_d %>">
             <%= price.to_html %>
           </span>
         <% end %>

--- a/app/views/spree/components/products/_product_form.html.erb
+++ b/app/views/spree/components/products/_product_form.html.erb
@@ -13,7 +13,7 @@
     <%= render 'spree/components/products/product_submit' %>
   <% else %>
     <div id="product-price">
-      <p class="price selling" itemprop="price">
+      <p itemprop="price">
         <%= t('spree.product_not_available_in_this_currency') %>
       </p>
     </div>

--- a/app/views/spree/components/products/_product_submit.html.erb
+++ b/app/views/spree/components/products/_product_submit.html.erb
@@ -1,7 +1,7 @@
 <div class="product-submit" id="product-price">
   <h2 class="product-submit__title">
     <span
-      class="price selling"
+      data-module="product-price"
       itemprop="price"
       content="<%= @product.price_for(current_pricing_options).to_d %>"
     >


### PR DESCRIPTION
Issue #84 

Getting this over as a draft as I'm interested in how you feel about `data-module` being used.

I'll update the JavaScript formatting in a future commit based on [your style guide](https://github.com/nebulab/playbook/blob/master/development/style-guide.html.md)

## Description
Replace CSS class names in JavaScript for `data` attributes.

## Motivation and Context
- Keeps styling and logic separate
- Prevent logic-based class names being deleted and functionality lost

## How Has This Been Tested?
I've been using a development Solidus store with the `solidus_starter_frontend` assets and views

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
I'd say this introduces a new-ish way of connection JavaScript and HTML via `data-module`. I've avoided the use of `ID`s as some of the event listeners are on elements with pre-existing `ID`s.

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.