### PR TITLE
Restore add to cart image selector

### DIFF
--- a/app/assets/javascripts/spree/frontend/product.js
+++ b/app/assets/javascripts/spree/frontend/product.js
@@ -1,13 +1,12 @@
 window.addEventListener('DOMContentLoaded', () => {
-  const radios = document.querySelectorAll('#product-variants input[type="radio"]');
-  const thumbnailsLinks = document.querySelectorAll('.js-product-thumbnail a');
-  const productImage = document.querySelector('.js-product-main-image');
-  const variantsThumbnails = document.querySelectorAll('.js-variant-thumbnail');
+  const radios = document.querySelectorAll("[data-js='variant-radio']");
+  const thumbnailsLinks = document
+    .querySelectorAll("[data-js='product-thumbnail'] a, [data-js='variant-thumbnail'] a");
+  const productImage = document.querySelector("[data-js='product-main-image']");
+  const variantsThumbnails = document.querySelectorAll("[data-js='variant-thumbnail']");
 
   if (radios.length > 0) {
-    const selectedRadio = document
-      .querySelector('#product-variants input[type="radio"][checked="checked"]');
-
+    const selectedRadio = document.querySelector("[data-js='variant-radio'][checked='checked']");
     updateVariantPrice(selectedRadio);
     updateVariantImages(selectedRadio.value);
   }
@@ -27,14 +26,14 @@ window.addEventListener('DOMContentLoaded', () => {
   });
 
   function updateVariantPrice(variant) {
-    const variantPrice = variant.dataset.price;
+    const variantPrice = variant.dataset.jsPrice;
     if (variantPrice) {
-      document.querySelector('.price.selling').innerHTML = variantPrice;
+      document.querySelector("[data-js='price']").innerHTML = variantPrice;
     }
   };
 
   function updateVariantImages(variantId) {
-    selector = "[data-js-product-thumbnail-variant-id='" + variantId + "']";
+    selector = "[data-js='variant-thumbnail'][data-js-id='" + variantId + "']";
     variantsThumbnailsToDisplay = document.querySelectorAll(selector);
 
     variantsThumbnails.forEach(thumbnail => {

--- a/app/assets/javascripts/spree/frontend/product.js
+++ b/app/assets/javascripts/spree/frontend/product.js
@@ -1,4 +1,31 @@
 window.addEventListener('DOMContentLoaded', () => {
+  const radios = document.querySelectorAll('#product-variants input[type="radio"]');
+  const thumbnailsLinks = document.querySelectorAll('.js-product-thumbnail a');
+  const productImage = document.querySelector('.js-product-main-image');
+  const variantsThumbnails = document.querySelectorAll('.js-variant-thumbnail');
+
+  if (radios.length > 0) {
+    const selectedRadio = document
+      .querySelector('#product-variants input[type="radio"][checked="checked"]');
+
+    updateVariantPrice(selectedRadio);
+    updateVariantImages(selectedRadio.value);
+  }
+
+  radios.forEach(radio => {
+    radio.addEventListener('click', () => {
+      updateVariantPrice(radio);
+      updateVariantImages(radio.value);
+    });
+  });
+
+  thumbnailsLinks.forEach(thumbnailLink => {
+    thumbnailLink.addEventListener('click', (event) => {
+      event.preventDefault();
+      updateProductImage(thumbnailLink.href);
+    });
+  });
+
   function updateVariantPrice(variant) {
     const variantPrice = variant.dataset.price;
     if (variantPrice) {
@@ -6,16 +33,25 @@ window.addEventListener('DOMContentLoaded', () => {
     }
   };
 
-  const radios = document.querySelectorAll('#product-variants input[type="radio"]');
+  function updateVariantImages(variantId) {
+    selector = "[data-js-product-thumbnail-variant-id='" + variantId + "']";
+    variantsThumbnailsToDisplay = document.querySelectorAll(selector);
 
-  if (radios.length > 0) {
-    const selectedRadio = document
-      .querySelector('#product-variants input[type="radio"][checked="checked"]');
+    variantsThumbnails.forEach(thumbnail => {
+      thumbnail.style.display = 'none';
+    });
 
-    updateVariantPrice(selectedRadio);
+    variantsThumbnailsToDisplay.forEach(thumbnail => {
+      thumbnail.style.display = 'list-item';
+    });
+
+    if(variantsThumbnailsToDisplay.length) {
+      variantFirstImage = variantsThumbnailsToDisplay[0].querySelector('a').href
+      updateProductImage(variantFirstImage);
+    }
+  };
+
+  function updateProductImage(imageSrc) {
+    productImage.src = imageSrc;
   }
-
-  radios.forEach(radio => {
-    radio.addEventListener('click', () => updateVariantPrice(radio));
-  });
 });

--- a/app/views/spree/components/products/_product_form.html.erb
+++ b/app/views/spree/components/products/_product_form.html.erb
@@ -13,7 +13,7 @@
     <%= render 'spree/components/products/product_submit' %>
   <% else %>
     <div id="product-price">
-      <p class="price selling" itemprop="price">
+      <p data-js="price" itemprop="price">
         <%= t('spree.product_not_available_in_this_currency') %>
       </p>
     </div>

--- a/app/views/spree/components/products/_product_image.html.erb
+++ b/app/views/spree/components/products/_product_image.html.erb
@@ -3,5 +3,6 @@
     image: defined?(image) && image || @product.gallery.images.first,
     size: :product,
     itemprop: "image",
-    classes: 'js-product-main-image' %>
+    data: { js: 'product-main-image' }
+  %>
 </picture>

--- a/app/views/spree/components/products/_product_image.html.erb
+++ b/app/views/spree/components/products/_product_image.html.erb
@@ -2,5 +2,6 @@
   <%= render 'spree/shared/image',
     image: defined?(image) && image || @product.gallery.images.first,
     size: :product,
-    itemprop: "image" %>
+    itemprop: "image",
+    classes: 'js-product-main-image' %>
 </picture>

--- a/app/views/spree/components/products/_product_submit.html.erb
+++ b/app/views/spree/components/products/_product_submit.html.erb
@@ -1,12 +1,12 @@
 <div class="product-submit" id="product-price">
   <h2 class="product-submit__title">
-    <span
-      class="price selling"
-      itemprop="price"
-      content="<%= @product.price_for(current_pricing_options).to_d %>"
-    >
-      <%= display_price(@product) %>
-    </span>
+    <%= content_tag(
+      :span,
+      display_price(@product),
+      itemprop: 'price',
+      content: @product.price_for(current_pricing_options).to_d,
+      data: { js: 'price' }
+    ) %>
     <span
       itemprop="priceCurrency"
       content="<%= current_pricing_options.currency %>"

--- a/app/views/spree/components/products/_product_thumbnails.html.erb
+++ b/app/views/spree/components/products/_product_thumbnails.html.erb
@@ -1,18 +1,27 @@
 <% if @product.gallery.images.size > 1 %>
   <ul class="product-thumbnails">
     <% @product.gallery.images.each do |image| %>
+
       <% next if image.viewable_id != @product.master.id %>
-      <li>
+      <%= content_tag(
+        :li,
+        class: 'product-thumbnails__all js-product-thumbnail',
+        data: { js_product_thumbnail_variant_id: image.viewable_id }
+      ) do %>
         <%= link_to(image_tag(image.url(:mini)), image.url(:product)) %>
-      </li>
+      <% end %>
     <% end %>
 
     <% if @product.has_variants? %>
       <% @product.gallery.images.each do |image| %>
         <% next if image.viewable_id == @product.master.id %>
-        <li>
+        <%= content_tag(
+          :li,
+          class: 'product-thumbnails__variant js-product-thumbnail js-variant-thumbnail',
+          data: { js_product_thumbnail_variant_id: image.viewable_id }
+        ) do %>
           <%= link_to(image_tag(image.url(:mini)), image.url(:product)) %>
-        </li>
+        <% end %>
       <% end %>
     <% end %>
   </ul>

--- a/app/views/spree/components/products/_product_thumbnails.html.erb
+++ b/app/views/spree/components/products/_product_thumbnails.html.erb
@@ -5,8 +5,8 @@
       <% next if image.viewable_id != @product.master.id %>
       <%= content_tag(
         :li,
-        class: 'product-thumbnails__all js-product-thumbnail',
-        data: { js_product_thumbnail_variant_id: image.viewable_id }
+        class: 'product-thumbnails__all',
+        data: { js: 'product-thumbnail', js_id: image.viewable_id }
       ) do %>
         <%= link_to(image_tag(image.url(:mini)), image.url(:product)) %>
       <% end %>
@@ -17,8 +17,8 @@
         <% next if image.viewable_id == @product.master.id %>
         <%= content_tag(
           :li,
-          class: 'product-thumbnails__variant js-product-thumbnail js-variant-thumbnail',
-          data: { js_product_thumbnail_variant_id: image.viewable_id }
+          class: 'product-thumbnails__variant',
+          data: { js: 'variant-thumbnail', js_id: image.viewable_id }
         ) do %>
           <%= link_to(image_tag(image.url(:mini)), image.url(:product)) %>
         <% end %>

--- a/app/views/spree/components/products/_product_variants.html.erb
+++ b/app/views/spree/components/products/_product_variants.html.erb
@@ -3,7 +3,7 @@
 %>
 
 <% if variants.any? %>
-  <section class="product-variants" id="product-variants">
+  <section class="product-variants">
     <h2 class="product-variants__title">
       <%= t('spree.variants') %>
     </h2>
@@ -15,7 +15,7 @@
             'variant_id',
             variant.id,
             index == 0,
-            'data-price' => variant.price_for(current_pricing_options)
+            data: { js: 'variant-radio', js_price: variant.price_for(current_pricing_options).to_s }
           ) %>
 
           <%= label_tag "variant_id_#{ variant.id }" do %>

--- a/app/views/spree/shared/_image.html.erb
+++ b/app/views/spree/shared/_image.html.erb
@@ -3,13 +3,14 @@
   size = local_assigns.fetch(:size, :mini)
   itemprop = local_assigns.fetch(:itemprop, nil)
   classes = local_assigns.fetch(:classes, '')
+  data = local_assigns.fetch(:data, {})
 %>
 
 <% if image_url = image.try(:url, size) %>
   <% if image_alt = image.try(:alt) %>
-    <%= image_tag image_url, alt: image_alt, itemprop: itemprop, class: classes %>
+    <%= image_tag image_url, alt: image_alt, itemprop: itemprop, class: classes, data: data %>
   <% else %>
-    <%= image_tag image_url, itemprop: itemprop, class: classes %>
+    <%= image_tag image_url, itemprop: itemprop, class: classes, data: data %>
   <% end %>
 <% else %>
   <div class="image-placeholder <%= size %>"></div>

--- a/app/views/spree/shared/_image.html.erb
+++ b/app/views/spree/shared/_image.html.erb
@@ -1,11 +1,15 @@
-<% size ||= :mini %>
-<% itemprop ||= nil %>
+<%
+  # Optional props
+  size = local_assigns.fetch(:size, :mini)
+  itemprop = local_assigns.fetch(:itemprop, nil)
+  classes = local_assigns.fetch(:classes, '')
+%>
 
 <% if image_url = image.try(:url, size) %>
   <% if image_alt = image.try(:alt) %>
-    <%= image_tag image_url, alt: image_alt, itemprop: itemprop %>
+    <%= image_tag image_url, alt: image_alt, itemprop: itemprop, class: classes %>
   <% else %>
-    <%= image_tag image_url, itemprop: itemprop %>
+    <%= image_tag image_url, itemprop: itemprop, class: classes %>
   <% end %>
 <% else %>
   <div class="image-placeholder <%= size %>"></div>

--- a/spec/system/products_spec.rb
+++ b/spec/system/products_spec.rb
@@ -119,7 +119,7 @@ describe 'Visiting Products', type: :system, inaccessible: true do
 
       it 'on product page' do
         visit spree.product_path(product)
-        within('.price') do
+        within("[data-js='price']") do
           expect(page).to have_content('19.99 ₽')
         end
       end
@@ -170,7 +170,7 @@ describe 'Visiting Products', type: :system, inaccessible: true do
 
     it 'displays price of first variant listed', js: true do
       click_link product.name
-      within('#product-price') do
+      within("[data-js='price']") do
         expect(page).to have_content variant.price
         expect(page).not_to have_content I18n.t('spree.out_of_stock')
       end
@@ -180,7 +180,7 @@ describe 'Visiting Products', type: :system, inaccessible: true do
       product.master.stock_items.update_all count_on_hand: 0, backorderable: false
 
       click_link product.name
-      within('#product-price') do
+      within("[data-js='price']") do
         expect(page).not_to have_content I18n.t('spree.out_of_stock')
       end
     end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

During the refactor we postponed to reimplement the add to cart image selector.

## Description
<!--- Describe your changes in detail -->
The feature has been restored with a necessary but minimal javascript intervention.
The functionality behaves exactly the same way as the original Solidus Frontend.

- Clicking on the variant radio button shows only the list of variant-specific images.
- Clicking on a thumbnail updates the product main image.

## Screenshots (if appropriate):

| Before | After |
| -- | -- |
|![92247615-c2a95000-eec7-11ea-99af-2827cc9e3591](https://user-images.githubusercontent.com/3853105/92260452-33f0ff00-eed8-11ea-8369-a2387fea3223.png)|![screencapture-localhost-3000-products-solidus-t-shirt-2020-09-04-17_55_26](https://user-images.githubusercontent.com/3853105/92260467-3bb0a380-eed8-11ea-9a65-329aa9ffe304.png)|


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
