### PR TITLE
Check if localeSelector exists before using it

### DIFF
--- a/app/assets/javascripts/spree/frontend/locale_selector.js
+++ b/app/assets/javascripts/spree/frontend/locale_selector.js
@@ -1,7 +1,9 @@
 window.addEventListener('DOMContentLoaded', () => {
   const localeSelector = document.querySelector('.locale-selector select');
 
-  localeSelector.addEventListener('change', (event) => {
-    event.target.form.submit();
-  });
+  if(localeSelector) {
+    localeSelector.addEventListener('change', (event) => {
+      event.target.form.submit();
+    });
+  }
 });


### PR DESCRIPTION
When the application has a single locale set the locale selector element
is not present.

Closes #94 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
