### PR TITLE
Add help information about Solidus Compare

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ Execute our generator that will copy our component files in your project:
 If Solidus was already installed with solidus_frontend you will have to change
 all `Spree::Frontend::Config` in `SolidusStarterFrontend::Config`.
 
+## Development
+
+For information about contributing to this project please refer to this 
+[document](docs/development.md).
+
 ## About
 
 [![Nebulab][nebulab-logo]][nebulab]

--- a/bin/solidus_compare
+++ b/bin/solidus_compare
@@ -14,6 +14,16 @@ CONFIG_PATH = 'config/solidus_compare.yml'
 @cmd_options = {}
 ARGV.each do |arg|
   case arg
+  when '-h', '--help'
+    puts <<~HELP
+      Solidus Compare: a tool to detect changes between 2 repositories
+
+      Options:
+        -h or --help          : show this help
+        -s or --summary       : generate an XML summary of the files changed (used in CI)
+        -u or --update-ignore : update the config file setting the current hashes to ignore
+    HELP
+    exit 0
   when '-s', '--summary'
     @cmd_options[:summary] = true
   when '-u', '--update-ignore'

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,28 @@
+# Solidus Starter Frontend development information
+This document aims to give some extra information for developers that are going 
+to contribute to our `solidus_starter_frontend` component.
+
+## Solidus Compare tool
+`solidus_compare` is a tool that we created to keep track of the changes made to
+[solidus_frontend](https://github.com/solidusio/solidus/tree/master/frontend), 
+which we used as source project in the beginning.
+
+It is connected to our CI; when a new PR is opened, if a change is detected on 
+Solidus Frontend, the workflow will fail and it will report the files changed.
+
+In that case, it is needed to evaluate those changes and eventually apply them 
+to our component. After this step, it is possible to mark those changes as 
+"managed".
+
+In practical terms:
+- run locally `bin/solidus_compare` in any branch;
+- evaluate the diff of the changes shown in the console;
+- apply the required changes (if they are useful to the project);
+- run `bin/solidus_compare -u` which will update the hashes in the config file;
+- commit the changes and check the CI.
+
+The tool internally works in this way:
+- configuration file is loaded (`config/solidus_compare.yml`);
+- remote GIT source is updated using the parameters provided by the config file;
+- compare process is executed and a hash for each file is calculated;
+- if they match the hashes saved in the configuration there are no differences.


### PR DESCRIPTION
- Update the documentation to add development information
- Add -h (or --help) option to show the help section in `solidus_compare`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
