### PR TITLE
Fix flaky spec in checkout

### DIFF
--- a/spec/system/checkout_spec.rb
+++ b/spec/system/checkout_spec.rb
@@ -613,11 +613,11 @@ describe 'Checkout', type: :system, inaccessible: true do
         add_mug_to_cart
         visit spree.checkout_state_path(:address)
         fill_in_address
+        fill_in 'Customer E-Mail', with: 'test@example.com'
 
         state_name_css = "order_bill_address_attributes_state_name"
 
         select "Canada", from: "order_bill_address_attributes_country_id"
-        fill_in 'Customer E-Mail', with: 'test@example.com'
         fill_in state_name_css, with: xss_string
         fill_in "Zip", with: "H0H0H0"
 


### PR DESCRIPTION
Sometimes checkout spec fails due to a missing "order_bill_address_attributes_state_name" input element.

closes #116 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
