### PR TITLE
Fix missing translations spec module

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,5 +33,7 @@ RSpec.configure do |config|
 
   if Spree.solidus_gem_version < Gem::Version.new('2.11')
     config.extend Spree::TestingSupport::AuthorizationHelpers::Request, type: :system
+  else
+    config.include Spree::TestingSupport::Translations
   end
 end

--- a/spec/support/solidus.rb
+++ b/spec/support/solidus.rb
@@ -8,15 +8,7 @@ require 'spree/testing_support/order_walkthrough'
 require 'spree/testing_support/translations' unless Spree.solidus_gem_version < Gem::Version.new('2.11')
 
 RSpec.configure do |config|
-  if Spree.solidus_gem_version < Gem::Version.new('2.11')
-    config.after(:each, type: :system) do |example|
-      missing_translations = page.body.scan(/translation missing: #{I18n.locale}\.(.*?)[\s<\"&]/)
-      if missing_translations.any?
-        puts "Found missing translations: #{missing_translations.inspect}\n"
-        puts "In spec: #{example.location}"
-      end
-    end
-  end
+  config.include Spree::TestingSupport::Translations unless Spree.solidus_gem_version < Gem::Version.new('2.11')
 
   if SolidusSupport.reset_spree_preferences_deprecated?
     config.before :suite do


### PR DESCRIPTION
The conditional require (on Solidus version check > 2.11) is loading the
file for missing translations check but the module must be loaded in RSpec
config to avoid the method missing.

Perhaps we could propose a PR to Solidus to include the module implicitly in the translations file: [here](https://github.com/solidusio/solidus/blob/master/core/lib/spree/testing_support/translations.rb#L17).

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
