### PR TITLE
Add the solidus_i18n gem to the sandbox

### DIFF
--- a/bin/sandbox
+++ b/bin/sandbox
@@ -56,6 +56,8 @@ gem 'solidus_core'
 gem 'solidus_api'
 gem 'solidus_backend'
 gem 'solidus_sample'
+gem 'rails-i18n'
+gem 'solidus_i18n'
 gem '$extension_name', path: '..'
 gem 'solidus_auth_devise'
 RUBY


### PR DESCRIPTION
Closes #119

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR adds the gem [solidus_i18n](https://github.com/solidusio/solidus_i18n) to the sandbox.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The gem is present in the dummy app but was missing from the sandbox. Its presence is required to show the locale selector in the storefront.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

I've run the sandbox using [this guide](https://github.com/nebulab/solidus_starter_frontend/blob/master/docs/development.md#running-the-sandbox) making sure that the locale selector was visible.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
