### PR TITLE
Use name over deprecated firstname and lastname

### DIFF
--- a/app/views/spree/address/_form_hidden.html.erb
+++ b/app/views/spree/address/_form_hidden.html.erb
@@ -1,5 +1,4 @@
-<%= form.hidden_field :firstname %>
-<%= form.hidden_field :lastname %>
+<%= form.hidden_field :name %>
 <%= form.hidden_field :company %>
 <%= form.hidden_field :address1 %>
 <%= form.hidden_field :address2 %>

--- a/app/views/spree/checkout/payment/_gateway.html.erb
+++ b/app/views/spree/checkout/payment/_gateway.html.erb
@@ -7,7 +7,7 @@
     id: "name_on_card_#{payment_method.id}",
     label: t('spree.name_on_card'),
     name: "#{param_prefix}[name]",
-    value: @order.try(:billing_name) || "#{@order.billing_firstname} #{@order.billing_lastname}"
+    value: @order.billing_name
   ) %>
 
   <%= render(

--- a/app/views/spree/components/forms/_address_inputs.html.erb
+++ b/app/views/spree/components/forms/_address_inputs.html.erb
@@ -9,21 +9,11 @@
     "spree/components/forms/inputs/text",
     autocomplete: "#{address_type} given-name",
     autofocus: true,
-    id: generate_id(form, "firstname"),
-    label: I18n.t("spree.first_name"),
-    name: "#{form.object_name}[firstname]",
+    id: generate_id(form, "name"),
+    label: I18n.t("spree.name"),
+    name: "#{form.object_name}[name]",
     required: true,
-    value: address.firstname
-  ) %>
-
-  <%= render(
-    "spree/components/forms/inputs/text",
-    autocomplete: "#{address_type} family-name",
-    id: generate_id(form, "lastname"),
-    label: I18n.t("spree.last_name"),
-    name: "#{form.object_name}[lastname]",
-    required: false,
-    value: address.lastname
+    value: address.name
   ) %>
 
   <% if Spree::Config[:company] %>

--- a/app/views/spree/components/orders/_address_overview.html.erb
+++ b/app/views/spree/components/orders/_address_overview.html.erb
@@ -10,7 +10,7 @@
   ) unless @order.completed? %>
 
   <ul class="address-overview__info">
-    <li><%= address.full_name %></li>
+    <li><%= address.name %></li>
     <% unless address.company.blank? %>
       <li><%= address.company %></li>
     <% end %>

--- a/spec/system/checkout_spec.rb
+++ b/spec/system/checkout_spec.rb
@@ -113,16 +113,16 @@ describe 'Checkout', type: :system, inaccessible: true do
       end
 
       context "when user has default addresses saved" do
-        let(:saved_bill_address) { create(:address, firstname: 'Bill') }
-        let(:saved_ship_address) { create(:address, firstname: 'Steve') }
+        let(:saved_bill_address) { create(:address, name: 'Bill Gates') }
+        let(:saved_ship_address) { create(:address, name: 'Steve Jobs') }
 
         it 'shows the saved addresses', js: true do
           within("#billing") do
-            expect(find_field('First Name').value).to eq 'Bill'
+            expect(find_field('Name').value).to eq 'Bill Gates'
           end
 
           within("#shipping") do
-            expect(find_field('First Name').value).to eq 'Steve'
+            expect(find_field('Name').value).to eq 'Steve Jobs'
           end
         end
       end
@@ -133,11 +133,11 @@ describe 'Checkout', type: :system, inaccessible: true do
 
         it 'shows an empty address', js: true do
           within("#billing") do
-            expect(find_field('First Name').value).to be_blank
+            expect(find_field('Name').value).to be_blank
           end
 
           within("#shipping") do
-            expect(find('input[name*="firstname"]', visible: :hidden).value).to be_blank
+            expect(find('input[name*="[name]"]', visible: :hidden).value).to be_blank
           end
         end
       end
@@ -150,11 +150,11 @@ describe 'Checkout', type: :system, inaccessible: true do
           click_button "Checkout"
 
           within("#billing") do
-            expect(find_field('First Name').value).to be_blank
+            expect(find_field('Name').value).to be_blank
           end
 
           within("#shipping") do
-            expect(find('input[name*="firstname"]', visible: :hidden).value).to be_blank
+            expect(find('input[name*="[name]"]', visible: :hidden).value).to be_blank
           end
         end
       end
@@ -183,27 +183,27 @@ describe 'Checkout', type: :system, inaccessible: true do
 
           it 'shows empty addresses', js: true do
             within("#billing") do
-              expect(find_field('First Name').value).to be_blank
+              expect(find_field('Name').value).to be_blank
             end
 
             within("#shipping") do
-              expect(find('input[name*="firstname"]', visible: :hidden).value).to be_blank
+              expect(find('input[name*="[name]"]', visible: :hidden).value).to be_blank
             end
           end
         end
 
         # Regression test for https://github.com/solidusio/solidus/issues/1811
         context "when does have saved addresses" do
-          let(:saved_bill_address) { create(:address, firstname: 'Bill') }
-          let(:saved_ship_address) { create(:address, firstname: 'Steve') }
+          let(:saved_bill_address) { create(:address, name: 'Bill Gates') }
+          let(:saved_ship_address) { create(:address, name: 'Steve Jobs') }
 
           it 'shows empty addresses', js: true do
             within("#billing") do
-              expect(find_field('First Name').value).to eq 'Bill'
+              expect(find_field('Name').value).to eq 'Bill Gates'
             end
 
             within("#shipping") do
-              expect(find_field('First Name').value).to eq 'Steve'
+              expect(find_field('Name').value).to eq 'Steve Jobs'
             end
           end
         end
@@ -396,7 +396,7 @@ describe 'Checkout', type: :system, inaccessible: true do
 
       click_on "Checkout"
       # edit an address field
-      fill_in "order_bill_address_attributes_firstname", with: "Ryann"
+      fill_in "order_bill_address_attributes_name", with: "Ryann"
       click_on "Save and Continue"
       click_on "Save and Continue"
       click_on "Save and Continue"
@@ -681,8 +681,7 @@ describe 'Checkout', type: :system, inaccessible: true do
 
   def fill_in_address
     address = "order_bill_address_attributes"
-    fill_in "#{address}_firstname", with: "Ryan"
-    fill_in "#{address}_lastname", with: "Bigg"
+    fill_in "#{address}_name", with: "Ryan Bigg"
     fill_in "#{address}_address1", with: "143 Swan Street"
     fill_in "#{address}_city", with: "Richmond"
     select "United States of America", from: "#{address}_country_id"

--- a/spec/system/coupon_code_spec.rb
+++ b/spec/system/coupon_code_spec.rb
@@ -42,8 +42,7 @@ describe 'Coupon code promotions', type: :system, js: true do
           click_button "add-to-cart-button"
           click_button "Checkout"
           fill_in "order_email", with: "spree@example.com"
-          fill_in "First Name", with: "John"
-          fill_in "Last Name", with: "Smith"
+          fill_in "Name", with: "John Smith"
           fill_in 'Street Address:', with: '1 John Street'
           fill_in "City", with: "City of John"
           fill_in "Zip", with: "01337"

--- a/spec/system/first_order_promotion_spec.rb
+++ b/spec/system/first_order_promotion_spec.rb
@@ -48,8 +48,7 @@ describe 'First Order promotion', type: :system do
 
   def fill_in_address
     address = "order_bill_address_attributes"
-    fill_in "#{address}_firstname", with: "Ryan"
-    fill_in "#{address}_lastname", with: "Bigg"
+    fill_in "#{address}_name", with: "Ryan Bigg"
     fill_in "#{address}_address1", with: "143 Swan Street"
     fill_in "#{address}_city", with: "Richmond"
     select "United States of America", from: "#{address}_country_id"

--- a/spec/system/free_shipping_promotions_spec.rb
+++ b/spec/system/free_shipping_promotions_spec.rb
@@ -34,8 +34,7 @@ describe 'Free shipping promotions', type: :system, js: true do
       click_button "add-to-cart-button"
       click_button "Checkout"
       fill_in "order_email", with: "spree@example.com"
-      fill_in "First Name", with: "John"
-      fill_in "Last Name", with: "Smith"
+      fill_in "Name", with: "John Smith"
       fill_in 'Street Address:', with: '1 John Street'
       fill_in "City", with: "City of John"
       fill_in "Zip", with: "01337"


### PR DESCRIPTION
Closes #99 

<!--- Provide a general summary of your changes in the Title above -->

Removes all occurrences of firstname and lastname methods or field names.

And of course, it will make the following two deprecations to disappear:
`DEPRECATION WARNING: firstname`
`DEPRECATION WARNING: lastname`

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
