### PR TITLE
Fix cache issue in sidebar

### DIFF
--- a/app/views/spree/components/navigation/_taxonomies.html.erb
+++ b/app/views/spree/components/navigation/_taxonomies.html.erb
@@ -1,7 +1,7 @@
 <% max_level = Spree::Config[:max_level_in_taxons_menu] || 1 %>
 
 <nav class="taxonomies">
-  <% cache [I18n.locale, taxonomies, max_level] do %>
+  <% cache [I18n.locale, taxonomies, @taxon, max_level] do %>
     <% taxonomies.each do |taxonomy| %>
       <% cache [I18n.locale, taxonomy, @taxon, max_level] do %>
         <%= render(

--- a/spec/system/taxons_spec.rb
+++ b/spec/system/taxons_spec.rb
@@ -155,4 +155,20 @@ describe 'viewing products', type: :system, inaccessible: true do
       end
     end
   end
+
+  context 'with more taxons', caching: true do
+    let!(:more_clothing) { create(:taxon, name: "More Clothing", parent: taxonomy.root, taxonomy: taxonomy) }
+
+    before do
+      visit '/t/category/super-clothing/t-shirts'
+    end
+
+    it 'changes the current taxon' do
+      expect(page).to have_css('.taxonomies li:first.current')
+      expect(page).to have_no_css('.taxonomies li:last.current')
+      find('.taxonomies a[href*="more-clothing"]').click
+      expect(page).to have_no_css('.taxonomies li:first.current')
+      expect(page).to have_css('.taxonomies li:last.current')
+    end
+  end
 end


### PR DESCRIPTION
Related to #79, and hopefully closes it - but I would ask more eyes here for more checks, it could be that I missed something.

## Description
- When cache is enabled, the taxonomies current element is not updated because the outside cache key is not considering the current taxon.

## How Has This Been Tested?
- Enabled cache: `bin/rails dev:cache`
- Went to the categories section
- Switched categories

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
