### PR TITLE
Move the price under the product info

### DIFF
--- a/app/views/spree/components/products/_product_info.html.erb
+++ b/app/views/spree/components/products/_product_info.html.erb
@@ -3,6 +3,20 @@
     <%= @product.name %>
   </h1>
 
+  <h2 class="product-submit__title">
+    <%= content_tag(
+      :span,
+      display_price(@product),
+      itemprop: 'price',
+      content: @product.price_for(current_pricing_options).to_d,
+      data: { js: 'price' }
+    ) %>
+    <span
+      itemprop="priceCurrency"
+      content="<%= current_pricing_options.currency %>"
+    ></span>
+  </h2>
+
   <p class="product-info__description" itemprop="description">
     <%= product_description(@product) rescue t('spree.product_has_no_description') %>
   </p>

--- a/app/views/spree/components/products/_product_submit.html.erb
+++ b/app/views/spree/components/products/_product_submit.html.erb
@@ -1,18 +1,4 @@
-<div class="product-submit" id="product-price">
-  <h2 class="product-submit__title">
-    <%= content_tag(
-      :span,
-      display_price(@product),
-      itemprop: 'price',
-      content: @product.price_for(current_pricing_options).to_d,
-      data: { js: 'price' }
-    ) %>
-    <span
-      itemprop="priceCurrency"
-      content="<%= current_pricing_options.currency %>"
-    ></span>
-  </h2>
-
+<div class="product-submit" id="product-price"
   <%= render 'spree/components/products/product_availability', product: @product %>
 
   <div class="horizontal-input-group">


### PR DESCRIPTION
## Motivation and Context
Generally, the price displays under the name of the product to be more visible for the user.