### PR TITLE
Copy missing solidus_support_extensions during the installation

### DIFF
--- a/lib/generators/solidus_starter_frontend/solidus_starter_frontend_generator.rb
+++ b/lib/generators/solidus_starter_frontend/solidus_starter_frontend_generator.rb
@@ -9,8 +9,14 @@ class SolidusStarterFrontendGenerator < Rails::Generators::Base
     directory 'lib/views', 'lib/views'
 
     # Copy files
-    copy_file 'lib/solidus_starter_frontend/config.rb', 'lib/solidus_starter_frontend/config.rb'
     copy_file 'lib/solidus_starter_frontend_configuration.rb', 'lib/solidus_starter_frontend_configuration.rb'
+    copy_file 'lib/solidus_starter_frontend/config.rb', 'lib/solidus_starter_frontend/config.rb'
+    copy_file 'lib/solidus_starter_frontend/solidus_support_extensions.rb', 'lib/solidus_starter_frontend/solidus_support_extensions.rb'
+
+    # Initializer
+    initializer 'solidus_starter_frontend.rb' do
+      "require 'solidus_starter_frontend/solidus_support_extensions'"
+    end
 
     # Routes
     copy_file 'config/routes.rb', 'tmp/routes.rb'

--- a/lib/generators/solidus_starter_frontend/solidus_starter_frontend_generator.rb
+++ b/lib/generators/solidus_starter_frontend/solidus_starter_frontend_generator.rb
@@ -24,6 +24,7 @@ class SolidusStarterFrontendGenerator < Rails::Generators::Base
 
     # Gems
     gem 'canonical-rails'
+    gem 'solidus_support'
     gem 'truncate_html'
 
     # Text updates


### PR DESCRIPTION
Closes #137.

## Description
- Copy _solidus_support_extensions.rb_ during the installation
- Prepare an initializer to load it in the target application

## How Has This Been Tested?
- Prepared a new Solidus app
- Executed the install procedure
- Checked in console `SolidusSupport.frontend_available?`

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
