### PR TITLE
Ignore gemfile used for local dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 .project
 .sass-cache
 coverage
+Gemfile-local
 Gemfile.lock
 tmp
 nbproject


### PR DESCRIPTION
## Description
The `Gemfile` allows for a developer to have a `Gemfile-local` file to
add extra dependencies.

## Motivation and Context
 We need to ignore it so that we don't accidentally add it to the repo.

## How Has This Been Tested?


## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
