### PR TITLE
Update test to use discard instead of paranoia

### DIFF
--- a/spec/system/checkout_spec.rb
+++ b/spec/system/checkout_spec.rb
@@ -336,7 +336,7 @@ describe 'Checkout', type: :system, inaccessible: true do
   end
 
   context "user has payment sources", js: true do
-    before { Spree::PaymentMethod.all.each(&:really_destroy!) }
+    before { Spree::PaymentMethod.all.each(&:destroy!) }
     let!(:bogus) { create(:credit_card_payment_method) }
     let(:user) { create(:user) }
 


### PR DESCRIPTION
Ref solidusio/solidus@b0092d0f3

## Description
The Master branch on solidus is not using paranoia anymore, so we need to update from our end.

It wasn't caught by the CI because, if I'm not wrong, it's using released solidus versions.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
