### PR TITLE
Remove dependency to test generators

### DIFF
--- a/solidus_starter_frontend.gemspec
+++ b/solidus_starter_frontend.gemspec
@@ -30,7 +30,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'canonical-rails', '~> 0.2.0'
-  spec.add_dependency 'generator_spec', '~> 0.9.4'
   spec.add_dependency 'solidus_api', ['>= 2.0', '< 4']
   spec.add_dependency 'solidus_core', ['>= 2.0.0', '< 4']
   spec.add_dependency 'solidus_support', '~> 0.5'

--- a/spec/generators/solidus/views/override_generator_spec.rb
+++ b/spec/generators/solidus/views/override_generator_spec.rb
@@ -1,50 +1,48 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'generator_spec'
 require 'generators/solidus_starter_frontend/views/override_generator'
 
-RSpec.describe SolidusStarterFrontend::Views::OverrideGenerator, type: :generator do
-  destination Rails.root.join('app', 'views', 'spree')
+RSpec.describe SolidusStarterFrontend::Views::OverrideGenerator do
+  include SolidusStarterFrontend::TestingSupport::Generators
 
-  before(:all) do
-    prepare_destination
+  def src
+    SolidusStarterFrontend::Engine.root.join('app', 'views', 'spree')
   end
 
-  subject! do
-    run_generator arguments
+  def dest
+    root.join('app', 'views', 'spree')
   end
 
-  let(:src) do
-    ::SolidusStarterFrontend::Engine.root.join('app', 'views', 'spree')
+  def ensure_clean_state
+    FileUtils.rm_rf dest if File.exist?(dest)
   end
 
-  let(:dest) do
-    Rails.root.join('app', 'views', 'spree')
+  around(:each) do |example|
+    ensure_clean_state
+    example.run
+    ensure_clean_state
   end
 
   context 'without any arguments' do
-    let(:arguments) { %w() }
-
     it 'copies all views into the host app' do
+      run 'solidus_starter_frontend:views:override'
+
       expect(src.entries).to match_array(dest.entries)
     end
   end
 
   context 'when "products" is passed as --only argument' do
-    let(:arguments) { %w(--only products) }
-
     context 'as folder' do
       it 'exclusively copies views whose name contains "products"' do
-        Dir.glob(dest.join("**", "*")).each do |file|
+        run 'solidus_starter_frontend:views:override --only products'
+
+        Dir.glob(dest.join('**', '*')).each do |file|
           next if File.directory?(file)
-          expect(file.to_s).to match("products")
+
+          expect(file.to_s).to match('products')
         end
       end
     end
-  end
-
-  after do
-    FileUtils.rm_rf destination_root
   end
 end

--- a/spec/support/solidus_starter_frontend/testing_support/generators.rb
+++ b/spec/support/solidus_starter_frontend/testing_support/generators.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module SolidusStarterFrontend
+  module TestingSupport
+    # Helper methods to test generators
+    module Generators
+      # Run given generator in the dummy application
+      #
+      # @param generator [String] Generator to execute as it would be given in
+      # the command line, including possible options
+      def run(generator)
+        `cd #{root} && bin/rails generate #{generator}`
+      end
+
+      private
+
+      def root
+        Rails.root
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description

The dependency that was in use in order to help testing generators have
not been updated since 2017 (ATTOW).

There's an alternative library that seems better maintained
(https://github.com/alexrothenberg/ammeter).

However, as we already have the dummy application our setup is very
simple and we don't need any external dependency.

This is preliminary work to implement what is described in https://github.com/nebulab/solidus_starter_frontend/pull/153#issuecomment-811093166.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
