### PR TITLE
Update gemspec to allow Solidus 3

### DIFF
--- a/solidus_starter_frontend.gemspec
+++ b/solidus_starter_frontend.gemspec
@@ -31,8 +31,8 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'canonical-rails', '~> 0.2.0'
   spec.add_dependency 'generator_spec', '~> 0.9.4'
-  spec.add_dependency 'solidus_api', ['>= 2.0', '< 3']
-  spec.add_dependency 'solidus_core', ['>= 2.0.0', '< 3']
+  spec.add_dependency 'solidus_api', ['>= 2.0', '< 4']
+  spec.add_dependency 'solidus_core', ['>= 2.0.0', '< 4']
   spec.add_dependency 'solidus_support', '~> 0.5'
   spec.add_dependency 'truncate_html', '~> 0.9', '>= 0.9.2'
 


### PR DESCRIPTION
## Description

This is needed because the last version of Solidus is 3.0