### PR TITLE
Update compare hash

### DIFF
--- a/config/solidus_compare.yml
+++ b/config/solidus_compare.yml
@@ -13,17 +13,17 @@ ignore:
     skip: true
   - file: app/controllers/concerns/solidus_starter_frontend/taxonomies.rb
     skip: true
-  - hash: 1422395649
+  - hash: 1367447392
     file: frontend/app/controllers/spree/coupon_codes_controller.rb
-  - hash: 2175977023
+  - hash: 641190994
     file: frontend/app/controllers/spree/home_controller.rb
-  - hash: 61096156
+  - hash: 842902636
     file: frontend/app/controllers/spree/products_controller.rb
   - hash: 1682079912
     file: frontend/app/controllers/spree/store_controller.rb
-  - hash: 910927973
+  - hash: 2171827236
     file: frontend/app/controllers/spree/taxons_controller.rb
-  - hash: 3582561552
+  - hash: 3587971972
     file: frontend/app/controllers/spree/content_controller.rb
 - path: app/helpers
   diffs: []

--- a/config/solidus_compare.yml
+++ b/config/solidus_compare.yml
@@ -1,29 +1,29 @@
 ---
 project_paths:
-- app/controllers
-- app/helpers
+  - app/controllers
+  - app/helpers
 source_repo: https://github.com/solidusio/solidus.git
 source_name: solidus
 source_branch: master
 source_base_path: frontend/
 ignore:
-- path: app/controllers
-  diffs:
-  - file: app/controllers/concerns/solidus_starter_frontend/auth_views.rb
-    skip: true
-  - file: app/controllers/concerns/solidus_starter_frontend/taxonomies.rb
-    skip: true
-  - hash: 1367447392
-    file: frontend/app/controllers/spree/coupon_codes_controller.rb
-  - hash: 641190994
-    file: frontend/app/controllers/spree/home_controller.rb
-  - hash: 842902636
-    file: frontend/app/controllers/spree/products_controller.rb
-  - hash: 1682079912
-    file: frontend/app/controllers/spree/store_controller.rb
-  - hash: 2171827236
-    file: frontend/app/controllers/spree/taxons_controller.rb
-  - hash: 3587971972
-    file: frontend/app/controllers/spree/content_controller.rb
-- path: app/helpers
-  diffs: []
+  - path: app/controllers
+    diffs:
+      - file: app/controllers/concerns/solidus_starter_frontend/auth_views.rb
+        skip: true
+      - file: app/controllers/concerns/solidus_starter_frontend/taxonomies.rb
+        skip: true
+      - hash: 1422395649
+        file: frontend/app/controllers/spree/coupon_codes_controller.rb
+      - hash: 2175977023
+        file: frontend/app/controllers/spree/home_controller.rb
+      - hash: 61096156
+        file: frontend/app/controllers/spree/products_controller.rb
+      - hash: 1682079912
+        file: frontend/app/controllers/spree/store_controller.rb
+      - hash: 910927973
+        file: frontend/app/controllers/spree/taxons_controller.rb
+      - hash: 3587971972
+        file: frontend/app/controllers/spree/content_controller.rb
+  - path: app/helpers
+    diffs: []


### PR DESCRIPTION
When we introduced #9 (https://github.com/nebulab/solidus_starter_frontend/pull/9/commits/a226ddb0c3e922a676cfef923232318ce13d81d2), we forgot to update the hash of contents that warns us when something changes in core.

Being the content_controller removed here, the diff was obviously failing because those files are different.

Still not sure why this didn't happen a while ago.