### PR TITLE
Fix <section> tag on product promotion component

### DIFF
--- a/app/views/spree/components/products/_product_promotions.html.erb
+++ b/app/views/spree/components/products/_product_promotions.html.erb
@@ -21,5 +21,5 @@
         <% end %>
       </article>
     <% end %>
-  <section>
+  </section>
 <% end %>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
While using your project I realized that the `<section>` tag was not closed on app/views/spree/components/products/_product_promotions.html.erb

Thanks for this awesome project

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
