### PR TITLE
Fix docker-compose referencing WIP setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,9 +39,6 @@ services:
       DB_POSTGRES_HOST: postgres
       HISTFILE: "/home/solidus_starter_frontend_user/history/bash_history"
       MYSQL_HISTFILE: "/home/solidus_starter_frontend_user/history/mysql_history"
-      # TODO: Remove repo/branch config when PR is merged
-      SOLIDUS_REPO: 'nebulab/solidus'
-      SOLIDUS_BRANCH: 'docker'
     ports:
       - "${SANDBOX_PORT:-3000}:${SANDBOX_PORT:-3000}"
     volumes:


### PR DESCRIPTION
References #149

## Description
While preparing the docker setup for this repo, we relied on a WIP work on the solidus gem. As it has already been merged (see solidusio/solidus#3947) we don't need it anymore. I.e., we merged #149 before updating it.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
