### PR TITLE
Fix installation method as a gem executable

### DIFF
--- a/lib/generators/solidus_starter_frontend/views/override_generator.rb
+++ b/lib/generators/solidus_starter_frontend/views/override_generator.rb
@@ -7,7 +7,7 @@ module SolidusStarterFrontend
   module Views
     class OverrideGenerator < ::Rails::Generators::Base
       def self.views_folder
-        Engine.root.join('app', 'views', 'spree')
+        Rails.root.join('app', 'views', 'spree')
       end
 
       VIEWS = Dir.glob(views_folder.join('**', '*'))

--- a/lib/solidus_starter_frontend.rb
+++ b/lib/solidus_starter_frontend.rb
@@ -6,7 +6,6 @@ require 'canonical-rails'
 require 'solidus_core'
 require 'solidus_support'
 
-require 'solidus_starter_frontend/solidus_support_extensions'
 require 'solidus_starter_frontend/version'
 require 'solidus_starter_frontend/config'
 require 'solidus_starter_frontend/engine'

--- a/lib/solidus_starter_frontend/engine.rb
+++ b/lib/solidus_starter_frontend/engine.rb
@@ -9,6 +9,10 @@ module SolidusStarterFrontend
 
     engine_name 'solidus_starter_frontend'
 
+    initializer 'solidus_starter_frontend', before: 'solidus_support_frontend_paths' do
+      Rails.configuration.x.solidus.frontend_available = true
+    end
+
     # use rspec for tests
     config.generators do |g|
       g.test_framework :rspec

--- a/lib/solidus_starter_frontend/solidus_support_extensions.rb
+++ b/lib/solidus_starter_frontend/solidus_support_extensions.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-require 'solidus_support'
-
-module SolidusSupport
-  def self.frontend_available?
-    true
-  end
-end


### PR DESCRIPTION
This is a WIP that depends on changes that need to be integrated on [`solidus_support`](https://github.com/solidusio/solidus_support). In order to try it:

- Check out this branch or your local repository.
- Make sure you don't have other installation of `solidus_starter_frontend`: `gem uninstall solidus_starter_frontend`
- Install the gem from this branch:
  - `gem build solidus_starter_frontend.gemspec`
  - `gem install solidus_starter_frontend-0.1.0.gem`
- Create a rails app: `rails new store --skip-javascript && cd store`
- Add solidus gems: `bundle add solidus_core solidus_backend solidus_api solidus_sample`
- **IMPORTANT**: Add `gem 'solidus_support', github: 'waiting-for-dev/solidus_support', branch: 'waiting-for-dev/change_engine_detection'` to the `Gemfile`
- Run `bundle`
- Run `bin/rails g solidus:install`
- Say `y` to the prompt suggesting `solidus_auth_devise`
- Run `solidus_starter_frontend`
- Run rails server `bin/rails server`
- Go to `http://localhost:3000` and check that the devise routes are working. E.g., `http://localhost:3000/login`.

## Description

To support `solidus_auth_devise`, it needs to rely on a new version of
`solidus_support` that changes how it detects if a Solidus frontend is
available and the moment it adds the extensions' controller & view
directories to the Rails known paths.

## Motivation and Context

The previous `solidus_support` version added the extensions' paths on
the engine's (in this case, `solidus_auth_devise`'s engine) load time
and only when `SolidusSupport#frontend_available?` returned `true`.
Engines are loaded before the application code, so at that time, the
monkey patching of `#frontend_available?` that we were generating was
not at hand. The solution is two-fold: we add the paths on an
`initializer` on one side. However, at that moment, the application code
is neither available, so on the other side, we change
`#frontend_available?` to look for a
`Rails.configuration.x.solidius.frontend_available` setting that we add
to `application.rb` using the generator code. To understand the whole
picture, keep in mind that `Rails.configuration` is available on an
initializer, but it's not on an engine's load time.
On top of that, we need to update a couple of things on the generated code:

- We need to reference `Rails.root` instead of `Engine.root`, as
  `SolidusStarterFrontend::Engine` is unavailable on this installation
  method.
- We need to copy to `application.rb` the custom code on
  `SolidusStarterFrontend::Engine` for the same reason as above.

## How Has This Been Tested?
Tested the installation method locally.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

References #153 & #161
