### PR TITLE
Fix price_for deprecation warnings

### DIFF
--- a/app/views/spree/components/products/_product-card.html.erb
+++ b/app/views/spree/components/products/_product-card.html.erb
@@ -26,7 +26,7 @@
         </h2>
       </header>
       <section class="product-card_price" itemprop="offers" itemscope itemtype="http://schema.org/Offer">
-        <% if price = product.price_for(current_pricing_options) %>
+        <% if price = product.price_for_options(current_pricing_options)&.money %>
           <span class="price selling" itemprop="price" content="<%= price.to_d %>">
             <%= price.to_html %>
           </span>

--- a/app/views/spree/components/products/_product_form.html.erb
+++ b/app/views/spree/components/products/_product_form.html.erb
@@ -9,7 +9,7 @@
 <%= form_for :order, url: populate_orders_path, html: schema_properties do |f| %>
   <%= render 'spree/components/products/product_variants' %>
 
-  <% if @product.price_for(current_pricing_options) and !@product.price.nil? %>
+  <% if @product.price_for_options(current_pricing_options)&.money and !@product.price.nil? %>
     <%= render 'spree/components/products/product_submit' %>
   <% else %>
     <div id="product-price">

--- a/app/views/spree/components/products/_product_price.html.erb
+++ b/app/views/spree/components/products/_product_price.html.erb
@@ -1,10 +1,10 @@
-<% if @product.price_for(current_pricing_options) and !@product.price.nil? %>
+<% if @product.price_for_options(current_pricing_options)&.money and !@product.price.nil? %>
   <h2 class="product-price" id="product-price">
     <%= content_tag(
       :span,
       display_price(@product),
       itemprop: 'price',
-      content: @product.price_for(current_pricing_options).to_d,
+      content: @product.price_for_options(current_pricing_options)&.money.to_d,
       data: { js: 'price' }
     ) %>
 

--- a/app/views/spree/components/products/_product_variants.html.erb
+++ b/app/views/spree/components/products/_product_variants.html.erb
@@ -15,7 +15,7 @@
             'variant_id',
             variant.id,
             index == 0,
-            data: { js: 'variant-radio', js_price: variant.price_for(current_pricing_options).to_s }
+            data: { js: 'variant-radio', js_price: variant.price_for_options(current_pricing_options)&.money.to_s }
           ) %>
 
           <%= label_tag "variant_id_#{ variant.id }" do %>


### PR DESCRIPTION
From https://github.com/solidusio/solidus/blob/ac6306090ab4b7e6ddd52dbcb33c7f181227c311/core/app/models/spree/variant/price_selector.rb#L28:

> price_for is deprecated and will be removed. The price_for method
> should return a Spree::Price as described. Please use
> #price_for_options and adjust your frontend code to explicitly call
> &.money where required

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
