### PR TITLE
Fix sandbox script

### DIFF
--- a/bin/sandbox
+++ b/bin/sandbox
@@ -58,13 +58,19 @@ cat <<RUBY >> Gemfile
 # By default, the solidus gem also includes the standard frontend via
 # the solidus_frontend gem. To make this extension work, you need to
 # exclude it and manually include all the other Solidus components.
-gem 'solidus_core'
-gem 'solidus_api'
-gem 'solidus_backend'
-gem 'solidus_sample'
+
+solidus_repo = ENV.fetch('SOLIDUS_REPO', 'solidusio/solidus')
+solidus_branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
+solidus_i18n_repo = ENV.fetch('SOLIDUS_I18N_REPO', 'solidusio/solidus_i18n')
+solidus_i18n_branch = ENV.fetch('SOLIDUS_I18N_BRANCH', 'master')
+
+gem 'solidus_core', github: solidus_repo, branch: solidus_branch
+gem 'solidus_api', github: solidus_repo, branch: solidus_branch
+gem 'solidus_backend', github: solidus_repo, branch: solidus_branch
+gem 'solidus_sample', github: solidus_repo, branch: solidus_branch
+gem 'solidus_i18n', github: solidus_i18n_repo, branch: solidus_i18n_branch
+
 gem 'rails-i18n'
-gem 'solidus_i18n'
-gem '$extension_name', path: '..'
 gem 'solidus_auth_devise'
 RUBY
 
@@ -93,7 +99,7 @@ unbundled bundle install --gemfile Gemfile
 
 unbundled bundle exec rake db:drop db:create
 
-unbundled bundle exec rails generate spree:install \
+unbundled bundle exec rails generate solidus:install \
   --auto-accept \
   --user_class=Spree::User \
   --enforce_available_locales=true \
@@ -101,8 +107,8 @@ unbundled bundle exec rails generate spree:install \
   --payment-method=none \
   $@
 
-unbundled bundle exec rails generate solidus:auth:install --auto-accept
-unbundled bundle exec rails generate ${extension_name}:install --auto-accept
+unbundled bundle exec rails generate solidus:auth:install --auto-run-migrations
+unbundled ../exe/${extension_name}
 
 echo
 echo "🚀 Sandbox app successfully created for $extension_name!"


### PR DESCRIPTION
## Description

* Point solidus gems in sandbox Gemfile to those in
solidus_starter_frontend's Gemfile.

* Remove solidus_starter_frontend from sandbox's Gemfile.

* Fix: Install solidus using `solidus:install` instead of
`spree:install`.

* Fix: Pass `--auto-run-migrations` instead of `--auto-accept` to
`solidus:auth:install`.

* Run the solidus_starter_frontend installer directly from sandbox. Can
no longer call `rails generate solidus_starter_frontend:install` from
the sandbox because the extension has been removed from the sandbox's
Gemfile in this commit.

## How Has This Been Tested?

Manually ran `bin/sandbox`. 

## Screenshots (if appropriate):

Demo here: 

https://www.loom.com/share/c6022d758eed48beace61a5318cf996e.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
