### PR TITLE
Discourage SolidusStarterFrontend from being run as an engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,16 +42,8 @@ If Solidus was already installed with _solidus_frontend_ you will have to
 replace all the references of the string `Spree::Frontend::Config` in your 
 project with `SolidusStarterFrontend::Config`.
 
-You have the following 2 install methods available.
+To install:
 
-### (1) Copy our components files in your project
-With this method, our views, assets, and controllers will be copied over your 
-project and you can change easily anything that we created; this gives you a lot
-of freedom of customization. On the other hand, you won't be able to auto-update
-the storefront code with the next versions released since it will not be present
-in your Gemfile.
-
-Installation steps:
 ```shell
 $ cd your/project/
 $ gem install solidus_starter_frontend
@@ -59,18 +51,6 @@ $ solidus_starter_frontend
 ```
 
 The last command will copy all the necessary files.
-
-### (2) Add our component as gem in your project
-With this method, you simply add our gem to your application and it behaves like
-a Rails engine. In this case, our files remain in the gem and you will need to
-override the views that you want to customize or if you need different logics to
-monkey-patch the classes that we previously defined.
-
-Installation steps:
-- add to your _Gemfile_: `gem 'solidus_starter_frontend'`
-
-**IMPORTANT**: put this line before `gem 'solidus_auth_devise'` (if you are 
-using this gem) because our component has conditional references to it.
 
 ## Development
 For information about contributing to this project please refer to this

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require 'solidus_dev_support/rake_tasks'
+
+ENV['SOLIDUS_STARTER_FRONTEND_ALLOW_AS_ENGINE'] = 'true'
 SolidusDevSupport::RakeTasks.install
 
 task default: 'extension:specs'

--- a/docs/development.md
+++ b/docs/development.md
@@ -25,7 +25,17 @@ Simply add this require statement to your spec_helper:
 require 'solidus_starter_frontend/factories'
 ```
 
+### Running the extension in development
+
+In order to run the extension, you can either 1) run the sandbox script to
+generate the sandbox app or 2) add the extension as a gem in a Rails app.
+
 ### Running the sandbox
+
+The sandbox script uses the `solidus_starter_frontend:install` generator to
+install the frontend. This is useful when you want to ensure that the generator
+is working.
+
 To run this extension in a sandboxed Solidus application, you can run 
 `bin/sandbox`. The path for the sandbox app is `./sandbox` and `bin/rails` will 
 forward any Rails commands to `sandbox/bin/rails`.
@@ -41,6 +51,63 @@ Use Ctrl-C to stop
 ```
 
 Default username and password for admin are: `admin@example.com` and `test123`.
+
+### Running the extension as an engine in a Rails app
+
+You can also run the extension as a engine in a Rails app. This is useful when
+you want to automatically see changes in the app without having to rerun the
+`solidus_starter_frontend:install` generator.
+
+To run the extension in a Rails app,
+
+#### 1) Create a Rails app
+
+```sh
+rails new store
+```
+
+#### 2) Add and install Solidus with `solidus_starter_frontend` in the Rails app
+
+Add the following gems. Since we're developing `solidus_starter_frontend`, we're
+assuming that you have `solidus_starter_frontend` locally and that you want to
+point to the latest versions of the Solidus components and extensions.
+
+```rb
+solidus_repo = ENV.fetch('SOLIDUS_REPO', 'solidusio/solidus')
+solidus_branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
+gem 'solidus_core', github: solidus_repo, branch: solidus_branch
+gem 'solidus_api', github: solidus_repo, branch: solidus_branch
+gem 'solidus_backend', github: solidus_repo, branch: solidus_branch
+gem 'solidus_sample', github: solidus_repo, branch: solidus_branch
+
+gem 'solidus_starter_frontend', path: 'path/to/solidus_starter_frontend'
+
+solidus_auth_devise_repo = ENV.fetch('SOLIDUS_AUTH_DEVISE_REPO', 'solidusio/solidus_auth_devise')
+solidus_auth_devise_branch = ENV.fetch('SOLIDUS_AUTH_DEVISE_BRANCH', 'master')
+gem 'solidus_auth_devise', github: solidus_auth_devise_repo, branch: solidus_auth_devise_branch
+```
+
+Note that `solidus_starter_frontend` has conditional references to
+`solidus_auth_devise`, so it's important to place `solidus_starter_frontend`
+before `solidus_auth_devise`.
+
+#### 3) Install Solidus
+
+```sh
+bundle exec rails generate solidus:install \
+  --auto-accept \
+  --user_class=Spree::User \
+  --enforce_available_locales=true \
+  --with-authentication=false \
+  --payment-method=none
+
+bundle exec rails generate solidus:auth:install --auto-run-migrations
+```
+
+#### 4) Install the frontend assets
+
+You will need to run `bundle exec rails g solidus_starter_frontend:install` to add the
+frontend assets to the existing vendored Solidus manifest files.
 
 ### Updating the changelog
 Before and after releases the changelog should be updated to reflect the 

--- a/docs/development.md
+++ b/docs/development.md
@@ -30,7 +30,7 @@ require 'solidus_starter_frontend/factories'
 In order to run the extension, you can either 1) run the sandbox script to
 generate the sandbox app or 2) add the extension as a gem in a Rails app.
 
-### Running the sandbox
+#### Running the sandbox
 
 The sandbox script uses the `solidus_starter_frontend:install` generator to
 install the frontend. This is useful when you want to ensure that the generator
@@ -52,7 +52,7 @@ Use Ctrl-C to stop
 
 Default username and password for admin are: `admin@example.com` and `test123`.
 
-### Running the extension as an engine in a Rails app
+#### Running the extension as an engine in a Rails app
 
 You can also run the extension as a engine in a Rails app. This is useful when
 you want to automatically see changes in the app without having to rerun the
@@ -60,13 +60,13 @@ you want to automatically see changes in the app without having to rerun the
 
 To run the extension in a Rails app,
 
-#### 1) Create a Rails app
+##### 1) Create a Rails app
 
 ```sh
 rails new store
 ```
 
-#### 2) Add and install Solidus with `solidus_starter_frontend` in the Rails app
+##### 2) Add and install Solidus with `solidus_starter_frontend` in the Rails app
 
 Add the following gems. Since we're developing `solidus_starter_frontend`, we're
 assuming that you have `solidus_starter_frontend` locally and that you want to
@@ -91,7 +91,7 @@ Note that `solidus_starter_frontend` has conditional references to
 `solidus_auth_devise`, so it's important to place `solidus_starter_frontend`
 before `solidus_auth_devise`.
 
-#### 3) Enable `SOLIDUS_STARTER_FRONTEND_ALLOW_AS_ENGINE` environment variable
+##### 3) Enable `SOLIDUS_STARTER_FRONTEND_ALLOW_AS_ENGINE` environment variable
 
 We're strongly encouraging people to use `solidus_starter_frontend` as a
 generator. Thus, if you want to run it as an engine, you'll need to set an
@@ -104,7 +104,7 @@ One way to do this is to set the environment variable within an initializer:
 ENV['SOLIDUS_STARTER_FRONTEND_ALLOW_AS_ENGINE'] = 'true'
 ```
 
-#### 3) Install Solidus
+##### 3) Install Solidus
 
 ```sh
 bundle exec rails generate solidus:install \
@@ -117,12 +117,12 @@ bundle exec rails generate solidus:install \
 bundle exec rails generate solidus:auth:install --auto-run-migrations
 ```
 
-#### 4) Install the frontend assets
+##### 4) Install the frontend assets
 
 You will need to run `bundle exec rails g solidus_starter_frontend:install` to add the
 frontend assets to the existing vendored Solidus manifest files.
 
-#### 5) Run the server
+##### 5) Run the server
 
 ```sh
 rails server

--- a/docs/development.md
+++ b/docs/development.md
@@ -91,6 +91,19 @@ Note that `solidus_starter_frontend` has conditional references to
 `solidus_auth_devise`, so it's important to place `solidus_starter_frontend`
 before `solidus_auth_devise`.
 
+#### 3) Enable `SOLIDUS_STARTER_FRONTEND_ALLOW_AS_ENGINE` environment variable
+
+We're strongly encouraging people to use `solidus_starter_frontend` as a
+generator. Thus, if you want to run it as an engine, you'll need to set an
+environment variable explicitly stating so.
+
+One way to do this is to set the environment variable within an initializer:
+
+```sh
+# config/initializers/solidus_starter_frontend.rb
+ENV['SOLIDUS_STARTER_FRONTEND_ALLOW_AS_ENGINE'] = 'true'
+```
+
 #### 3) Install Solidus
 
 ```sh
@@ -108,6 +121,12 @@ bundle exec rails generate solidus:auth:install --auto-run-migrations
 
 You will need to run `bundle exec rails g solidus_starter_frontend:install` to add the
 frontend assets to the existing vendored Solidus manifest files.
+
+#### 5) Run the server
+
+```sh
+rails server
+```
 
 ### Updating the changelog
 Before and after releases the changelog should be updated to reflect the 

--- a/lib/solidus_starter_frontend/engine.rb
+++ b/lib/solidus_starter_frontend/engine.rb
@@ -15,6 +15,8 @@ module SolidusStarterFrontend
     end
 
     config.to_prepare do
+      raise 'Error: SolidusStarterFrontend is not allowed to run as an engine' unless ENV['SOLIDUS_STARTER_FRONTEND_ALLOW_AS_ENGINE']
+
       if defined?(Spree::Auth::Engine)
         [
           Spree::UserConfirmationsController,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 
 # Configure Rails Environment
 ENV['RAILS_ENV'] = 'test'
+ENV['SOLIDUS_STARTER_FRONTEND_ALLOW_AS_ENGINE'] = 'true'
 
 # Run Coverage report
 require 'solidus_dev_support/rspec/coverage'


### PR DESCRIPTION
## Dependencies

Depends on https://github.com/nebulab/solidus_starter_frontend/pull/166.

## Motivation and Context

From https://www.notion.so/nebulab/Starter-FE-7f00e5d23f5841c1817beebfc8859d83:

> We want the new starter frontend to be opinionated and provide a single option which is the "right" way for building your storefront, so we should only allow people to install the starter frontend through a Rails generator and remove (or at the very least severely restrict) the ability to run it as a Rails engine.

## Walkthrough and Demo

Demo: https://www.loom.com/share/a7be0f380b944cce9678796e6c88be12

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
