### PR TITLE
Fix and update sandbox script

### DIFF
--- a/bin/sandbox
+++ b/bin/sandbox
@@ -58,12 +58,19 @@ cat <<RUBY >> Gemfile
 # By default, the solidus gem also includes the standard frontend via
 # the solidus_frontend gem. To make this extension work, you need to
 # exclude it and manually include all the other Solidus components.
-gem 'solidus_core'
-gem 'solidus_api'
-gem 'solidus_backend'
-gem 'solidus_sample'
+
+solidus_repo = ENV.fetch('SOLIDUS_REPO', 'solidusio/solidus')
+solidus_branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
+solidus_i18n_repo = ENV.fetch('SOLIDUS_I18N_REPO', 'solidusio/solidus_i18n')
+solidus_i18n_branch = ENV.fetch('SOLIDUS_I18N_BRANCH', 'master')
+
+gem 'solidus_core', github: solidus_repo, branch: solidus_branch
+gem 'solidus_api', github: solidus_repo, branch: solidus_branch
+gem 'solidus_backend', github: solidus_repo, branch: solidus_branch
+gem 'solidus_sample', github: solidus_repo, branch: solidus_branch
+gem 'solidus_i18n', github: solidus_i18n_repo, branch: solidus_i18n_branch
+
 gem 'rails-i18n'
-gem 'solidus_i18n'
 gem '$extension_name', path: '..'
 gem 'solidus_auth_devise'
 RUBY
@@ -93,7 +100,7 @@ unbundled bundle install --gemfile Gemfile
 
 unbundled bundle exec rake db:drop db:create
 
-unbundled bundle exec rails generate spree:install \
+unbundled bundle exec rails generate solidus:install \
   --auto-accept \
   --user_class=Spree::User \
   --enforce_available_locales=true \
@@ -101,8 +108,8 @@ unbundled bundle exec rails generate spree:install \
   --payment-method=none \
   $@
 
-unbundled bundle exec rails generate solidus:auth:install --auto-accept
-unbundled bundle exec rails generate ${extension_name}:install --auto-accept
+unbundled bundle exec rails generate solidus:auth:install --auto-run-migrations
+unbundled bundle exec rails g solidus_starter_frontend:install
 
 echo
 echo "🚀 Sandbox app successfully created for $extension_name!"


### PR DESCRIPTION
Goal
----

As a `solidus_starter_frontend` contributor
I want the gem's sandbox script to generate the app with the `solidus_starter_frontend gem` as an engine
So that the app would pick up changes I make to the app code

Background
----------

Currently, the sandbox script both loads the gem and runs its generator. We want it to only the load the gem.

Previous implementations
------------------------

* [Document how to run the extension as an engine in a Rails app](https://github.com/nebulab/solidus_starter_frontend/pull/167/commits/a4600e2f3d37dec4eacdf24a36e68ebd124d31b8) - This commit documents how to install solidus_starter_frontend as an engine.
* Fix sandbox script #166 - This PR fixed the script to run `solidus_starter_frontend`  as a generator instead of as a gem.

Relevant links
--------------

https://github.com/nebulab/solidus_starter_frontend/pull/167#discussion_r669313064 - discussion on having two strategies for generating the sandbox app: one with the Starter FE running as an engine and other where Starter FE is generated into the app.

Implementation
--------------

* Point solidus gems in sandbox Gemfile to those in
solidus_starter_frontend's Gemfile.

* Fix: Install solidus using `solidus:install` instead of
`spree:install`.

* Fix: Pass `--auto-run-migrations` instead of `--auto-accept` to
`solidus:auth:install`.

* Remove `solidus_starter_frontend` call.

* Call `bundle exec rails g solidus_starter_frontend:install`.

## Demo

https://www.loom.com/share/1c7c4ff55baf4d8d8404a77f8520ca30

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
