### PR TITLE
Include assets in layout

### DIFF
--- a/app/views/spree/layouts/spree_application.html.erb
+++ b/app/views/spree/layouts/spree_application.html.erb
@@ -9,7 +9,10 @@
     <%= csrf_meta_tags %>
 
     <%= javascript_include_tag 'spree/frontend/all' %>
+    <%= javascript_include_tag 'spree/frontend/solidus_starter_frontend' %>
+
     <%= stylesheet_link_tag 'spree/frontend/all', media: 'screen' %>
+    <%= stylesheet_link_tag 'spree/frontend/solidus_starter_frontend', media: 'screen' %>
 
     <%= favicon_link_tag 'favicon.ico' %>
     <%= yield :head %>

--- a/bin/sandbox
+++ b/bin/sandbox
@@ -109,7 +109,6 @@ unbundled bundle exec rails generate solidus:install \
   $@
 
 unbundled bundle exec rails generate solidus:auth:install --auto-run-migrations
-unbundled bundle exec rails g solidus_starter_frontend:install
 
 echo
 echo "🚀 Sandbox app successfully created for $extension_name!"

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,1 +1,5 @@
-Rails.application.config.assets.precompile << 'solidus_starter_frontend_manifest.js'
+Rails.application.config.assets.precompile += [
+  'solidus_starter_frontend_manifest.js',
+  'spree/frontend/solidus_starter_frontend.js',
+  'spree/frontend/solidus_starter_frontend.css'
+]

--- a/lib/generators/solidus_starter_frontend/solidus_starter_frontend_generator.rb
+++ b/lib/generators/solidus_starter_frontend/solidus_starter_frontend_generator.rb
@@ -33,5 +33,8 @@ class SolidusStarterFrontendGenerator < Rails::Generators::Base
     inject_into_file 'vendor/assets/stylesheets/spree/frontend/all.css', " *= require spree/frontend/solidus_starter_frontend\n", before: %r{\*/}, verbose: true
     inject_into_file 'config/initializers/spree.rb', "require_relative Rails.root.join('lib/solidus_starter_frontend/config')\n", before: /Spree.config do/, verbose: true
     gsub_file 'app/assets/stylesheets/application.css', '*= require_tree', '* OFF require_tree'
+
+    gsub_file 'app/views/spree/layouts/spree_application.html.erb', "<%= javascript_include_tag 'spree/frontend/solidus_starter_frontend' %>", ''
+    gsub_file 'app/views/spree/layouts/spree_application.html.erb', "<%= stylesheet_link_tag 'spree/frontend/solidus_starter_frontend', media: 'screen' %>", ''
   end
 end


### PR DESCRIPTION
Goal
----

As a `solidus_starter_frontend` contributor

I want the assets to be included in the layout

So that when I include the engine to a Solidus application, I no longer have to
run `bundle exec rails g solidus_starter_frontend:install` separately to add
the assets to the application.

Changes
-----------------------

* When I run `rails g solidus_starter_frontend:install`, the generator removes
  the asset tags from the layouts. The generator still adds those assets
  to the vendored all.* asset files.

## Dependencies

https://github.com/nebulab/solidus_starter_frontend/pull/169

## Demo

https://www.loom.com/share/393c57efb3d9411bae717405b6b6103c

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
