### PR TITLE
Extract VendorAssetsGenerator

### DIFF
--- a/bin/sandbox
+++ b/bin/sandbox
@@ -121,7 +121,7 @@ unbundled bundle exec rails generate solidus:install \
 unbundled bundle exec rails generate solidus:auth:install --auto-run-migrations
 
 if [[ -z $GENERATE_FRONTEND ]]; then
-  unbundled bundle exec rails g solidus_starter_frontend:install
+  unbundled bundle exec rails g solidus_starter_frontend:vendor_assets
 else
   ruby -I ../lib ../exe/${extension_name} --auto-accept
 fi

--- a/lib/generators/solidus_starter_frontend/install/install_generator.rb
+++ b/lib/generators/solidus_starter_frontend/install/install_generator.rb
@@ -1,14 +1,13 @@
 # frozen_string_literal: true
 
+require_relative '../vendor_assets_generator'
+
 module SolidusStarterFrontend
   module Generators
+    # This generator is called by solidus/core/lib/spree/testing_support/common_rake.rb.
     class InstallGenerator < Rails::Generators::Base
-      def add_javascripts
-        append_file 'vendor/assets/javascripts/spree/frontend/all.js', "//= require spree/frontend/solidus_starter_frontend\n"
-      end
-
-      def add_stylesheets
-        inject_into_file 'vendor/assets/stylesheets/spree/frontend/all.css', " *= require spree/frontend/solidus_starter_frontend\n", before: %r{\*/}, verbose: true
+      def vendor_assets
+        SolidusStarterFrontend::VendorAssetsGenerator.start
       end
     end
   end

--- a/lib/generators/solidus_starter_frontend/solidus_starter_frontend_generator.rb
+++ b/lib/generators/solidus_starter_frontend/solidus_starter_frontend_generator.rb
@@ -32,6 +32,17 @@ class SolidusStarterFrontendGenerator < Rails::Generators::Base
     inject_into_file 'config/initializers/spree.rb', "require_relative Rails.root.join('lib/solidus_starter_frontend/config')\n", before: /Spree.config do/, verbose: true
     gsub_file 'app/assets/stylesheets/application.css', '*= require_tree', '* OFF require_tree'
 
+    # We can't use Rails' `generate` method here to call
+    # `solidus_starter_frontend:vendor_assets`. When the
+    # solidus_starter_frontend generator is used as a standalone program
+    # (instead of added to an app's Gemfile), `generate` won't be able to pick
+    # up the other generators that the gem provides.
+    #
+    # We're able to use Thor's `invoke` action here instead of `generate`.
+    # However, `invoke` only works once per generator you want to call. Please
+    # see https://stackoverflow.com/a/12029262/65925 for more details.
+    #
+    # See also https://github.com/nebulab/solidus_starter_frontend/pull/174#discussion_r685626737.
     invoke 'solidus_starter_frontend:vendor_assets'
   end
 end

--- a/lib/generators/solidus_starter_frontend/solidus_starter_frontend_generator.rb
+++ b/lib/generators/solidus_starter_frontend/solidus_starter_frontend_generator.rb
@@ -29,9 +29,9 @@ class SolidusStarterFrontendGenerator < Rails::Generators::Base
 
     # Text updates
     append_file 'config/initializers/assets.rb', "Rails.application.config.assets.precompile += ['solidus_starter_frontend_manifest.js']"
-    append_file 'vendor/assets/javascripts/spree/frontend/all.js', "//= require spree/frontend/solidus_starter_frontend\n"
-    inject_into_file 'vendor/assets/stylesheets/spree/frontend/all.css', " *= require spree/frontend/solidus_starter_frontend\n", before: %r{\*/}, verbose: true
     inject_into_file 'config/initializers/spree.rb', "require_relative Rails.root.join('lib/solidus_starter_frontend/config')\n", before: /Spree.config do/, verbose: true
     gsub_file 'app/assets/stylesheets/application.css', '*= require_tree', '* OFF require_tree'
+
+    invoke 'solidus_starter_frontend:vendor_assets'
   end
 end

--- a/lib/generators/solidus_starter_frontend/vendor_assets_generator.rb
+++ b/lib/generators/solidus_starter_frontend/vendor_assets_generator.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module SolidusStarterFrontend
+  class VendorAssetsGenerator < Rails::Generators::Base
+    def add_javascripts
+      append_file 'vendor/assets/javascripts/spree/frontend/all.js', "//= require spree/frontend/solidus_starter_frontend\n"
+    end
+
+    def add_stylesheets
+      inject_into_file 'vendor/assets/stylesheets/spree/frontend/all.css', " *= require spree/frontend/solidus_starter_frontend\n", before: %r{\*/}, verbose: true
+    end
+  end
+end


### PR DESCRIPTION
Goal
----

As a `solidus_starter_frontend` contributor

I want to create a separate
`SolidusStarterFrontend::VendorAssetsGenerator`

So that the purposes and differences of the `SolidusStarterFrontend`
generators would be clearer:

* `SolidusStarterFrontend::Generators::InstallGenerator`
  - Used for setting up the extension in CI (see
    `solidus/core/lib/spree/testing_support/common_rake.rb`)
* `SolidusStarterFrontend::VendorAssetsGenerator`
  - Used for adding the JS and CSS files to the vendored all.*manifests.
* `SolidusStarterFrontendGenerator`
  - Called by users of the gem to install the starter frontend in their
    apps.

## Dependencies

Depends on https://github.com/nebulab/solidus_starter_frontend/pull/171

## Walkthrough

https://www.loom.com/share/5fecced6c0c9466da0157f8bb50cf905

## Demo

https://www.loom.com/share/a5ede129d3c14c938af543c0f4b04f86

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [N/A] Bug fix (non-breaking change which fixes an issue)
- [N/A] New feature (non-breaking change which adds functionality)
- [N/A] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [N/A] My code follows the code style of this project.
- [N/A] My change requires a change to the documentation.
- [N/A] I have updated the documentation accordingly.
