### PR TITLE
Fix: Inter fonts should be precompiled

### DIFF
--- a/app/assets/stylesheets/spree/frontend/base/_fonts.scss
+++ b/app/assets/stylesheets/spree/frontend/base/_fonts.scss
@@ -1,20 +1,20 @@
-$inter-font-path: 'base/fonts/inter/';
+$inter-font-path: 'spree/frontend/base/fonts/inter/';
 
 @font-face {
   font-family: 'Inter';
   font-style: normal;
   font-weight: 300;
   font-display: swap;
-  src: url('#{$inter-font-path}Inter-Light.woff2?v=3.15') format('woff2'),
-       url('#{$inter-font-path}Inter-Light.woff?v=3.15') format('woff');
+  src: font-url('#{$inter-font-path}Inter-Light.woff2?v=3.15') format('woff2'),
+       font-url('#{$inter-font-path}Inter-Light.woff?v=3.15') format('woff');
 }
 @font-face {
   font-family: 'Inter';
   font-style: italic;
   font-weight: 300;
   font-display: swap;
-  src: url('#{$inter-font-path}Inter-LightItalic.woff2?v=3.15') format('woff2'),
-       url('#{$inter-font-path}Inter-LightItalic.woff?v=3.15') format('woff');
+  src: font-url('#{$inter-font-path}Inter-LightItalic.woff2?v=3.15') format('woff2'),
+       font-url('#{$inter-font-path}Inter-LightItalic.woff?v=3.15') format('woff');
 }
 
 @font-face {
@@ -22,16 +22,16 @@ $inter-font-path: 'base/fonts/inter/';
   font-style: normal;
   font-weight: 500;
   font-display: swap;
-  src: url('#{$inter-font-path}Inter-Medium.woff2?v=3.15') format('woff2'),
-       url('#{$inter-font-path}Inter-Medium.woff?v=3.15') format('woff');
+  src: font-url('#{$inter-font-path}Inter-Medium.woff2?v=3.15') format('woff2'),
+       font-url('#{$inter-font-path}Inter-Medium.woff?v=3.15') format('woff');
 }
 @font-face {
   font-family: 'Inter';
   font-style: italic;
   font-weight: 500;
   font-display: swap;
-  src: url('#{$inter-font-path}Inter-MediumItalic.woff2?v=3.15') format('woff2'),
-       url('#{$inter-font-path}Inter-MediumItalic.woff?v=3.15') format('woff');
+  src: font-url('#{$inter-font-path}Inter-MediumItalic.woff2?v=3.15') format('woff2'),
+       font-url('#{$inter-font-path}Inter-MediumItalic.woff?v=3.15') format('woff');
 }
 
 @font-face {
@@ -39,14 +39,14 @@ $inter-font-path: 'base/fonts/inter/';
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url('#{$inter-font-path}Inter-Bold.woff2?v=3.15') format('woff2'),
-       url('#{$inter-font-path}Inter-Bold.woff?v=3.15') format('woff');
+  src: font-url('#{$inter-font-path}Inter-Bold.woff2?v=3.15') format('woff2'),
+       font-url('#{$inter-font-path}Inter-Bold.woff?v=3.15') format('woff');
 }
 @font-face {
   font-family: 'Inter';
   font-style: italic;
   font-weight: 700;
   font-display: swap;
-  src: url('#{$inter-font-path}Inter-BoldItalic.woff2?v=3.15') format('woff2'),
-       url('#{$inter-font-path}Inter-BoldItalic.woff?v=3.15') format('woff');
+  src: font-url('#{$inter-font-path}Inter-BoldItalic.woff2?v=3.15') format('woff2'),
+       font-url('#{$inter-font-path}Inter-BoldItalic.woff?v=3.15') format('woff');
 }


### PR DESCRIPTION
Expected behavior
-----------------

Given I am in the `solidus_starter_frontend` repo

And I have generated the sandbox app with precompiled assets

```
rm -rf sandbox
RAILS_ENV=production bin/rails assets:precompile
```

When I run the app in production environment

```
RAILS_ENV=production RAILS_SERVE_STATIC_FILES=1 bin/rails s
```

And I view the app in the browser

Then I should see that the Inter fonts are loaded

## Actual behavior

The browser cannot find the Inter fonts. Sample error message:

> GET http://localhost:3000/assets/spree/frontend/base/fonts/inter/Inter-Light.woff2?v=3.15 net::ERR_ABORTED 404 (Not Found)

![image](https://user-images.githubusercontent.com/61476/129643456-e83d078f-6efa-4f93-ae0b-de554aae2847.png)

## Additional requirements

### Inter fonts should also be precompiled in sandbox-generated app

Given I am in the `solidus_starter_frontend` repo

And I have generated the sandbox-generated app with precompiled assets

```sh
rm -rf sandbox-generated
GENERATE_FRONTEND=1 RAILS_ENV=production bin/rails assets:precompile
```

When I run the app in production environment

```sh
GENERATE_FRONTEND=1 RAILS_ENV=production RAILS_SERVE_STATIC_FILES=1 bin/rails s
```

And I view the app in the browser

Then I should see that the Inter fonts are loaded

## Bug demo

https://www.loom.com/share/f0e061fa8aa441e880b860536e7ce19d

## Tests

### Inter Fonts should be precompiled when `solidus_starter_frontend` is added as an engine to the sandbox app

https://www.loom.com/share/a76a24ff6b0c46ddb7dcffe91bd1fbf6

### Inter Fonts should be precompiled when `solidus_starter_frontend` is installed in a Solidus app

https://www.loom.com/share/9400348dc1654c3fb4a81db40a7e2d0c

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [N/A] New feature (non-breaking change which adds functionality)
- [N/A] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [N/A] My change requires a change to the documentation.
- [N/A] I have updated the documentation accordingly.
