### PR TITLE
Remove Spree::Core::ControllerHelpers line from Spree::UsersController

### DIFF
--- a/app/controllers/spree/users_controller.rb
+++ b/app/controllers/spree/users_controller.rb
@@ -5,7 +5,6 @@ class Spree::UsersController < Spree::StoreController
   prepend_before_action :load_object, only: [:show, :edit, :update]
   prepend_before_action :authorize_actions, only: :new
 
-  include Spree::Core::ControllerHelpers
   include SolidusStarterFrontend::Taxonomies
 
   def show


### PR DESCRIPTION
Goal
----

As a `solidus_starter_frontend` contributor

I want to remove the `include Spree::Core::ControllerHelpers` line from `Spree::UsersController`

So that the controller would be consistent with https://github.com/solidusio/solidus_auth_devise

Background
----------

From https://github.com/solidusio/solidus_auth_devise/commit/0ca9437caca542a550aca7ebcbe32c50e44e0427#diff-91e719b06965b47abb40a990b58c1f0bb27e1214f637e299dd9b0dc60d481dc2:

> Remove line that doesn't do anything
>
> This module doesn't have any methods. It's just a namespace that
> contains all the other controller concerns, but those concerns are
> included in Spree::StoreController, so as far as I can tell this line
> does nothing.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [N/A] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [N/A] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [N/A] My change requires a change to the documentation.
- [N/A] I have updated the documentation accordingly.
