### PR TITLE
Docker: Change public keys server after deprecation

### DIFF
--- a/.dockerdev/Dockerfile
+++ b/.dockerdev/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update -qq \
 RUN curl -sSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
   && echo 'deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main' $PG_VERSION > /etc/apt/sources.list.d/pgdg.list
 
-RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 8C718D3B5072E1F5 \
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 8C718D3B5072E1F5 \
  && echo "deb http://repo.mysql.com/apt/debian/ buster mysql-"$MYSQL_VERSION > /etc/apt/sources.list.d/mysql.list
 
 RUN curl -sSL https://deb.nodesource.com/setup_$NODE_VERSION.x | bash -


### PR DESCRIPTION
ha.pool.sks-keyservers.net has been deprecated, so we'll use
keyserver.ubuntu.com from this point on.

![127824897-be724eff-a816-4591-933a-ea71642ea218](https://user-images.githubusercontent.com/52650/129693267-f5c29221-5fe9-4015-9879-dc1a5b14f28e.png)