### PR TITLE
Update CI to run the specs in an app with a generated frontend

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ commands:
         default: master
       command:
         type: string
-        default: bundle exec rake
+        default: bundle exec rspec --format progress --format RspecJunitFormatter --out $TEST_RESULTS_PATH
       command_verb:
         type: string
         default: Runs tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,8 @@ commands:
       - run:
           name: 'Solidus <<parameters.branch>>:  Install gems'
           command: |
-            bundle install --path=vendor/bundle/<<parameters.branch>>
+            bundle config --local path vendor/bundle/<<parameters.branch>>
+            bundle install
             bundle clean
           environment:
             SOLIDUS_BRANCH: <<parameters.branch>>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,26 +63,20 @@ commands:
           name: 'Solidus <<parameters.branch>>: Clean up'
           when: always
 
-  run-tests-solidus-master:
-    description: >
-      Test the edge version of Solidus
-
-    steps:
-      - test-branch:
-          branch: master
-
 jobs:
   run-specs-with-postgres:
     executor: solidusio_extensions/postgres
     steps:
       - checkout
-      - run-tests-solidus-master
+      - test-branch:
+          branch: master
       - solidusio_extensions/store-test-results
   run-specs-with-mysql:
     executor: solidusio_extensions/mysql
     steps:
       - checkout
-      - run-tests-solidus-master
+      - test-branch:
+          branch: master
       - solidusio_extensions/store-test-results
   solidus-compare:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,8 @@ commands:
             GENERATE_FRONTEND: 1
             SANDBOX_BUNDLE_PATH: ../vendor/bundle/<<parameters.branch>>
             SOLIDUS_BRANCH: <<parameters.branch>>
+            SANDBOX_SKIP_SOLIDUS_INSTALL_SEED: true
+            SANDBOX_SKIP_SOLIDUS_INSTALL_SAMPLE: true
           when: always
       - save_cache:
           name: 'Solidus <<parameters.branch>>: Save Bundler cache'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,18 +7,82 @@ orbs:
   # or goes EOL.
   solidusio_extensions: solidusio/extensions@volatile
 
+commands:
+  test-branch:
+    description:
+      Runs tests for a specific Solidus branch.
+
+    parameters:
+      branch:
+        type: string
+        default: master
+      command:
+        type: string
+        default: bundle exec rake
+      command_verb:
+        type: string
+        default: Runs tests
+
+    steps:
+      - run:
+          name: 'Solidus <<parameters.branch>>: Generate Gemfile.lock'
+          command: bundle lock
+          environment:
+            SOLIDUS_BRANCH: <<parameters.branch>>
+          when: always
+      - restore_cache:
+          name: 'Solidus <<parameters.branch>>: Restore Bundler cache'
+          keys:
+            - gems-v3-ruby-v2-5-6-solidus-<<parameters.branch>>-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+            - gems-v3-ruby-v2-5-6-solidus-<<parameters.branch>>-master
+            - gems-v3-ruby-v2-5-6-solidus-<<parameters.branch>>-
+          when: always
+      - run:
+          name: 'Solidus <<parameters.branch>>:  Install gems'
+          command: |
+            bundle install --path=vendor/bundle/<<parameters.branch>>
+            bundle clean
+          environment:
+            SOLIDUS_BRANCH: <<parameters.branch>>
+          when: always
+      - save_cache:
+          name: 'Solidus <<parameters.branch>>: Save Bundler cache'
+          key: gems-v3-ruby-v2-5-6-solidus-<<parameters.branch>>-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+          paths:
+            - vendor/bundle/<<parameters.branch>>
+          when: always
+      - run:
+          name: '<<parameters.command_verb>> on Solidus <<parameters.branch>>'
+          command: <<parameters.command>>
+          environment:
+            SOLIDUS_BRANCH: <<parameters.branch>>
+            TEST_RESULTS_PATH: test-results/gems-v3-ruby-v2-5-6-solidus-<<parameters.branch>>/results.xml
+          when: always
+      - run:
+          command: rm -f Gemfile.lock && rm -fr spec/dummy
+          name: 'Solidus <<parameters.branch>>: Clean up'
+          when: always
+
+  run-tests-solidus-master:
+    description: >
+      Test the edge version of Solidus
+
+    steps:
+      - test-branch:
+          branch: master
+
 jobs:
   run-specs-with-postgres:
     executor: solidusio_extensions/postgres
     steps:
       - checkout
-      - solidusio_extensions/run-tests-solidus-master
+      - run-tests-solidus-master
       - solidusio_extensions/store-test-results
   run-specs-with-mysql:
     executor: solidusio_extensions/mysql
     steps:
       - checkout
-      - solidusio_extensions/run-tests-solidus-master
+      - run-tests-solidus-master
       - solidusio_extensions/store-test-results
   solidus-compare:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,9 @@ commands:
         default: master
       command:
         type: string
-        default: bundle exec rspec --format progress --format RspecJunitFormatter --out $TEST_RESULTS_PATH
+        default: |
+          cd sandbox-generated
+          bundle exec rspec --format progress --format RspecJunitFormatter --out $TEST_RESULTS_PATH
       command_verb:
         type: string
         default: Runs tests
@@ -33,6 +35,7 @@ commands:
       - restore_cache:
           name: 'Solidus <<parameters.branch>>: Restore Bundler cache'
           keys:
+            - gems-v3-ruby-v2-5-6-solidus-<<parameters.branch>>-{{ .Branch }}-sandbox-generated-{{ checksum "Gemfile.lock" }}
             - gems-v3-ruby-v2-5-6-solidus-<<parameters.branch>>-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
             - gems-v3-ruby-v2-5-6-solidus-<<parameters.branch>>-master
             - gems-v3-ruby-v2-5-6-solidus-<<parameters.branch>>-
@@ -46,9 +49,17 @@ commands:
           environment:
             SOLIDUS_BRANCH: <<parameters.branch>>
           when: always
+      - run:
+          name: 'Solidus <<parameters.branch>>:  Install sandbox with generated starter frontend'
+          command: bin/sandbox
+          environment:
+            GENERATE_FRONTEND: 1
+            SANDBOX_BUNDLE_PATH: ../vendor/bundle/<<parameters.branch>>
+            SOLIDUS_BRANCH: <<parameters.branch>>
+          when: always
       - save_cache:
           name: 'Solidus <<parameters.branch>>: Save Bundler cache'
-          key: gems-v3-ruby-v2-5-6-solidus-<<parameters.branch>>-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+          key: gems-v3-ruby-v2-5-6-solidus-<<parameters.branch>>-{{ .Branch }}-sandbox-generated-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle/<<parameters.branch>>
           when: always
@@ -57,10 +68,10 @@ commands:
           command: <<parameters.command>>
           environment:
             SOLIDUS_BRANCH: <<parameters.branch>>
-            TEST_RESULTS_PATH: test-results/gems-v3-ruby-v2-5-6-solidus-<<parameters.branch>>/results.xml
+            TEST_RESULTS_PATH: ../test-results/gems-v3-ruby-v2-5-6-solidus-<<parameters.branch>>/results.xml
           when: always
       - run:
-          command: rm -f Gemfile.lock && rm -fr spec/dummy
+          command: rm -f Gemfile.lock && rm -fr spec/dummy && rm -rf sandbox-generated
           name: 'Solidus <<parameters.branch>>: Clean up'
           when: always
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Just run:
 rails new store --skip-javascript
 cd store
 bundle add solidus_core solidus_backend solidus_api solidus_sample
+bundle add rspec-rails "~> 4.0.0.beta3"
 bin/rails generate solidus:install --auto-accept
 ```
 
@@ -43,6 +44,10 @@ Please note that `--auto-accept` will add [Solidus Auth Devise]
 (https://github.com/solidusio/solidus_auth_devise) to your application. At the
 moment, SolidusStarterFrontend requires the application to include the gem. In
 the future, we'll make Solidus Auth Devise optional.
+
+`rspec-rails` is required to install the frontend's test suite to your app. If
+you'd like to exclude the gem, you'll need to specify `--skip-specs` when you
+run `solidus_starter_frontend` later.
 
 ### For existing stores
 
@@ -67,6 +72,10 @@ project with `SolidusStarterFrontend::Config`.
 You'll also need to make sure that [Solidus Auth Devise]
 (https://github.com/solidusio/solidus_auth_devise) is installed in your
 application.
+
+Finally, please note that `rspec-rails ~> 4.0.0.beta3` is required to install
+the frontend's test suite to your app. If you'd like to exclude the gem, you'll
+need to specify `--skip-specs` when you run `solidus_starter_frontend` later.
 
 ### Frontend installation
 

--- a/README.md
+++ b/README.md
@@ -35,8 +35,7 @@ Just run:
 ```bash
 rails new store --skip-javascript
 cd store
-bundle add solidus_core solidus_backend solidus_api solidus_sample
-bundle add rspec-rails "~> 4.0.0.beta3"
+bundle add solidus_core solidus_backend solidus_api solidus_sample rspec-rails
 bin/rails generate solidus:install --auto-accept
 ```
 
@@ -73,7 +72,7 @@ You'll also need to make sure that [Solidus Auth Devise]
 (https://github.com/solidusio/solidus_auth_devise) is installed in your
 application.
 
-Finally, please note that `rspec-rails ~> 4.0.0.beta3` is required to install
+Finally, please note that `rspec-rails` is required to install
 the frontend's test suite to your app. If you'd like to exclude the gem, you'll
 need to specify `--skip-specs` when you run `solidus_starter_frontend` later.
 

--- a/bin/sandbox
+++ b/bin/sandbox
@@ -112,6 +112,10 @@ if [ ${PASSWORD} ]; then
   replace_in_database_yml "password" $PASSWORD
 fi
 
+if [[ -n $SANDBOX_BUNDLE_PATH ]]; then
+  bundle config --local path $SANDBOX_BUNDLE_PATH
+fi
+
 unbundled bundle install --gemfile Gemfile
 
 unbundled bundle exec rake db:drop db:create

--- a/bin/sandbox
+++ b/bin/sandbox
@@ -49,13 +49,8 @@ else
   GENERATOR_SKIP_SPECS_ARGUMENT=''
 fi
 
-# Stay away from the bundler env of the containing extension.
-function unbundled {
-  ruby -rbundler -e'b = proc {system *ARGV}; Bundler.respond_to?(:with_unbundled_env) ? Bundler.with_unbundled_env(&b) : Bundler.with_clean_env(&b)' -- $@
-}
-
 rm -rf ${sandbox_path}
-unbundled bundle exec rails new ${sandbox_name} --database="$RAILSDB" \
+bundle exec rails new ${sandbox_name} --database="$RAILSDB" \
   --skip-bundle \
   --skip-git \
   --skip-keeps \
@@ -116,11 +111,11 @@ if [[ -n $SANDBOX_BUNDLE_PATH ]]; then
   bundle config --local path $SANDBOX_BUNDLE_PATH
 fi
 
-unbundled bundle install --gemfile Gemfile
+bundle install --gemfile Gemfile
 
-unbundled bundle exec rake db:drop db:create
+bundle exec rake db:drop db:create
 
-unbundled bundle exec rails generate solidus:install \
+bundle exec rails generate solidus:install \
   --auto-accept \
   --user_class=Spree::User \
   --enforce_available_locales=true \
@@ -128,12 +123,12 @@ unbundled bundle exec rails generate solidus:install \
   --payment-method=none \
   $@
 
-unbundled bundle exec rails generate solidus:auth:install --auto-run-migrations
+bundle exec rails generate solidus:auth:install --auto-run-migrations
 
 if [[ -z $GENERATE_FRONTEND ]]; then
   if [[ -z $SKIP_SPECS ]]; then
-    unbundled bundle exec rails g solidus_starter_frontend:rspec
-    unbundled bundle exec rails g rspec:install
+    bundle exec rails g solidus_starter_frontend:rspec
+    bundle exec rails g rspec:install
   fi
 else
   ruby -I ../lib ../exe/${extension_name} --auto-accept $GENERATOR_SKIP_SPECS_ARGUMENT

--- a/bin/sandbox
+++ b/bin/sandbox
@@ -85,7 +85,7 @@ gem 'rails-i18n'
 ${extension_gem_line}
 gem 'solidus_auth_devise'
 
-gem 'rspec-rails', '~> 4.0.0.beta3'
+gem 'rspec-rails'
 RUBY
 
 replace_in_database_yml() {

--- a/bin/sandbox
+++ b/bin/sandbox
@@ -84,6 +84,8 @@ gem 'solidus_i18n', github: solidus_i18n_repo, branch: solidus_i18n_branch
 gem 'rails-i18n'
 ${extension_gem_line}
 gem 'solidus_auth_devise'
+
+gem 'rspec-rails', '~> 4.0.0.beta3'
 RUBY
 
 replace_in_database_yml() {

--- a/bin/sandbox
+++ b/bin/sandbox
@@ -38,7 +38,7 @@ if [[ -z $GENERATE_FRONTEND ]]; then
   extension_gem_line="gem '$extension_name', path: '..'"
 else
   sandbox_name='sandbox-generated'
-  extension_gem_line=""
+  extension_gem_line="gem '$extension_name', path: '..', require: false"
 fi
 
 sandbox_path="./${sandbox_name}"
@@ -131,7 +131,7 @@ if [[ -z $GENERATE_FRONTEND ]]; then
     bundle exec rails g rspec:install
   fi
 else
-  ruby -I ../lib ../exe/${extension_name} --auto-accept $GENERATOR_SKIP_SPECS_ARGUMENT
+  bundle exec ${extension_name} --auto-accept $GENERATOR_SKIP_SPECS_ARGUMENT
 fi
 
 echo

--- a/bin/sandbox
+++ b/bin/sandbox
@@ -117,12 +117,26 @@ bundle install --gemfile Gemfile
 
 bundle exec rake db:drop db:create
 
+if [[ -n $SANDBOX_SKIP_SOLIDUS_INSTALL_SEED ]]; then
+  sandbox_skip_solidus_install_seed_argument='--seed=false'
+else
+  sandbox_skip_solidus_install_seed_argument=''
+fi
+
+if [[ -n $SANDBOX_SKIP_SOLIDUS_INSTALL_SAMPLE ]]; then
+  sandbox_skip_solidus_install_sample_argument='--sample=false'
+else
+  sandbox_skip_solidus_install_sample_argument=''
+fi
+
 bundle exec rails generate solidus:install \
   --auto-accept \
   --user_class=Spree::User \
   --enforce_available_locales=true \
   --with-authentication=false \
   --payment-method=none \
+  $sandbox_skip_solidus_install_seed_argument \
+  $sandbox_skip_solidus_install_sample_argument \
   $@
 
 bundle exec rails generate solidus:auth:install --auto-run-migrations

--- a/lib/generators/solidus_starter_frontend/rspec_generator.rb
+++ b/lib/generators/solidus_starter_frontend/rspec_generator.rb
@@ -5,18 +5,12 @@ module SolidusStarterFrontend
     source_root File.expand_path('../../..', __dir__)
 
     def install
-      # solidus_dev_support 2.5.0 depends on these gem versions.
-      gsub_file 'Gemfile', /gem ['"]puma['"].*/, "# gem 'puma' # solidus_dev_support 2.5.0 depends on puma ~> 4.3. See puma declaration below."
-      gsub_file 'Gemfile', /gem ['"]rspec-rails['"].*/, "# gem 'rspec-rails' # solidus_dev_support 2.5.0 depends on rspec-rails ~> 4.0.0.beta3. See rspec-rails declaration below."
-
-      gem 'puma', '~> 4.3'
-
       gem_group :development, :test do
-        gem 'rspec-rails', '~> 4.0.0.beta3'
+        gem 'rspec-rails'
         gem 'apparition', '~> 0.6.0'
         gem 'rails-controller-testing', '~> 1.0.5'
         gem 'rspec-activemodel-mocks', '~> 1.1.0'
-        gem 'solidus_dev_support', '~> 2.0'
+        gem 'solidus_dev_support', '~> 2.5'
       end
 
       Bundler.with_original_env do

--- a/lib/generators/solidus_starter_frontend/rspec_generator.rb
+++ b/lib/generators/solidus_starter_frontend/rspec_generator.rb
@@ -5,11 +5,14 @@ module SolidusStarterFrontend
     source_root File.expand_path('../../..', __dir__)
 
     def install
-      # solidus_dev_support 2.5.0 depends on this puma version.
+      # solidus_dev_support 2.5.0 depends on these gem versions.
       gsub_file 'Gemfile', /gem ['"]puma['"].*/, "# gem 'puma' # solidus_dev_support 2.5.0 depends on puma ~> 4.3. See puma declaration below."
+      gsub_file 'Gemfile', /gem ['"]rspec-rails['"].*/, "# gem 'rspec-rails' # solidus_dev_support 2.5.0 depends on rspec-rails ~> 4.0.0.beta3. See rspec-rails declaration below."
+
       gem 'puma', '~> 4.3'
 
       gem_group :development, :test do
+        gem 'rspec-rails', '~> 4.0.0.beta3'
         gem 'apparition', '~> 0.6.0'
         gem 'rails-controller-testing', '~> 1.0.5'
         gem 'rspec-activemodel-mocks', '~> 1.1.0'

--- a/lib/generators/solidus_starter_frontend/rspec_generator.rb
+++ b/lib/generators/solidus_starter_frontend/rspec_generator.rb
@@ -16,6 +16,10 @@ module SolidusStarterFrontend
         gem 'solidus_dev_support', '~> 2.0'
       end
 
+      Bundler.with_original_env do
+        run 'bundle install'
+      end
+
       # Copy spec files
       directory 'spec/controllers'
       directory 'spec/helpers'

--- a/lib/generators/solidus_starter_frontend/solidus_starter_frontend_generator.rb
+++ b/lib/generators/solidus_starter_frontend/solidus_starter_frontend_generator.rb
@@ -24,6 +24,10 @@ class SolidusStarterFrontendGenerator < Rails::Generators::Base
     gem 'solidus_support'
     gem 'truncate_html'
 
+    Bundler.with_original_env do
+      run 'bundle install'
+    end
+
     # Text updates
     append_file 'config/initializers/assets.rb', "Rails.application.config.assets.precompile += ['solidus_starter_frontend_manifest.js']"
     inject_into_file 'config/initializers/spree.rb', "require_relative Rails.root.join('lib/solidus_starter_frontend/config')\n", before: /Spree.config do/, verbose: true

--- a/solidus_starter_frontend.gemspec
+++ b/solidus_starter_frontend.gemspec
@@ -39,5 +39,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'apparition', '~> 0.6.0'
   spec.add_development_dependency 'rails-controller-testing', '~> 1.0.5'
   spec.add_development_dependency 'rspec-activemodel-mocks', '~> 1.1.0'
-  spec.add_development_dependency 'solidus_dev_support', '~> 2.0'
+  spec.add_development_dependency 'solidus_dev_support', '~> 2.5'
 end


### PR DESCRIPTION
Goal
----

As a solidus_starter_frontend contributor

I want the CI to run the specs in an app with a generated frontend

So that I can be certain that SolidusStarterFrontendGenerator is generating
stable storefronts

## Walkthrough

## Part 1: `bin/sandbox`

https://www.loom.com/share/4906b64d62964e53aa58cbe0ac7e331b

This walkthrough covers the changes and fixes to `bin/sandbox`. These changes are needed to get `bin/sandbox` to run in CI.

## Part 2: `.circleci/config.yml`

https://www.loom.com/share/ca6ce8ac495041cf9d9320655075bca5

In this walkthrough, I show how the CI configured is changed to generate the sandbox app and run the specs from there. I also investigate the bundle path used by the specs.

This [CI run](https://app.circleci.com/pipelines/github/nebulab/solidus_starter_frontend/986/workflows/4c69056e-5b80-4b09-b37f-ea5aa7075f38/jobs/2603) confirms that both the gem dependencies and the sandbox gems are installed in the same `vendor/bundle/master` directory:

* `vendor/bundle/master` file count after "Install gems": 16459
* `vendor/bundle/master` file count after "Install sandbox with generated starter frontend": 17415

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [N/A] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
