### PR TITLE
Fix: solidus_starter_frontend cannot be installed on a fresh Solidus app

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ Just run:
 ```bash
 rails new store --skip-javascript
 cd store
-bundle add solidus_core solidus_backend solidus_api solidus_sample rspec-rails
+bundle add solidus_core solidus_backend solidus_api solidus_sample
+bundle add rspec-rails --group 'development, test'
 bin/rails generate solidus:install --auto-accept
 ```
 

--- a/bin/sandbox
+++ b/bin/sandbox
@@ -85,7 +85,7 @@ gem 'rails-i18n'
 ${extension_gem_line}
 gem 'solidus_auth_devise'
 
-gem 'rspec-rails'
+gem 'rspec-rails', groups: [:development, :test]
 RUBY
 
 replace_in_database_yml() {

--- a/lib/generators/solidus_starter_frontend/rspec_generator.rb
+++ b/lib/generators/solidus_starter_frontend/rspec_generator.rb
@@ -6,7 +6,6 @@ module SolidusStarterFrontend
 
     def install
       gem_group :development, :test do
-        gem 'rspec-rails'
         gem 'apparition', '~> 0.6.0'
         gem 'rails-controller-testing', '~> 1.0.5'
         gem 'rspec-activemodel-mocks', '~> 1.1.0'

--- a/lib/generators/solidus_starter_frontend/solidus_starter_frontend_generator.rb
+++ b/lib/generators/solidus_starter_frontend/solidus_starter_frontend_generator.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'bundler'
+
 class SolidusStarterFrontendGenerator < Rails::Generators::Base
   source_root File.expand_path('../../..', __dir__)
 


### PR DESCRIPTION
## Acceptance criteria

As a solidus_starter_frontend user, I should be able to successfully install `solidus_starter_frontend` on a fresh Solidus app by following the instructions from the README.

## Bug description

I encounter two errors:

* uninitialized constant `SolidusStarterFrontendGenerator::Bundler`
* You specified: rspec-rails (~> 5.0) and rspec-rails (>= 0). Bundler cannot continue.

## Bug demo

https://www.loom.com/share/bc9c36cec25f430f956dd0abf972eae0

## Fix walk-through and demo

https://www.loom.com/share/85d5b9085f3a44ef89ca401e34f28b72

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- N/A - New feature (non-breaking change which adds functionality)
- N/A - Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
