### PR TITLE
Add option to exclude authentication component when running generator

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,9 @@ commands:
       branch:
         type: string
         default: master
+      skip_authentication:
+        type: boolean
+        default: false
       command:
         type: string
         default: |
@@ -56,6 +59,7 @@ commands:
             GENERATE_FRONTEND: 1
             SANDBOX_BUNDLE_PATH: ../vendor/bundle/<<parameters.branch>>
             SOLIDUS_BRANCH: <<parameters.branch>>
+            SANDBOX_SKIP_AUTHENTICATION: <<parameters.skip_authentication>>
           when: always
       - save_cache:
           name: 'Solidus <<parameters.branch>>: Save Bundler cache'
@@ -76,6 +80,26 @@ commands:
           when: always
 
 jobs:
+  run-specs-with-postgres-for-generators:
+    executor: solidusio_extensions/postgres
+    steps:
+      - checkout
+      - solidusio_extensions/test-branch:
+          branch: master
+          command: |
+            bundle exec rspec spec/generators \
+              --format progress \
+              --format RspecJunitFormatter \
+              --out $TEST_RESULTS_PATH
+      - solidusio_extensions/store-test-results
+  run-specs-with-postgres-skipping-authentication:
+    executor: solidusio_extensions/postgres
+    steps:
+      - checkout
+      - test-branch:
+          branch: master
+          skip_authentication: true
+      - solidusio_extensions/store-test-results
   run-specs-with-postgres:
     executor: solidusio_extensions/postgres
     steps:
@@ -110,6 +134,8 @@ jobs:
 workflows:
   "Run specs on supported Solidus versions":
     jobs:
+      - run-specs-with-postgres-for-generators
+      - run-specs-with-postgres-skipping-authentication
       - run-specs-with-postgres
       - run-specs-with-mysql
       - solidus-compare
@@ -122,6 +148,8 @@ workflows:
               only:
                 - master
     jobs:
+      - run-specs-with-postgres-for-generators
+      - run-specs-with-postgres-skipping-authentication
       - run-specs-with-postgres
       - run-specs-with-mysql
       - solidus-compare

--- a/README.md
+++ b/README.md
@@ -37,13 +37,8 @@ rails new store --skip-javascript
 cd store
 bundle add solidus_core solidus_backend solidus_api solidus_sample
 bundle add rspec-rails --group 'development, test'
-bin/rails generate solidus:install --auto-accept
+bin/rails generate solidus:install
 ```
-
-Please note that `--auto-accept` will add [Solidus Auth Devise]
-(https://github.com/solidusio/solidus_auth_devise) to your application. At the
-moment, SolidusStarterFrontend requires the application to include the gem. In
-the future, we'll make Solidus Auth Devise optional.
 
 `rspec-rails` is required to install the frontend's test suite to your app. If
 you'd like to exclude the gem, you'll need to specify `--skip-specs` when you
@@ -93,9 +88,8 @@ anything that we created; this gives you a lot of freedom of customization.
 You can choose to exclude the RSpec test suite by running
 `solidus_starter_frontend --skip-specs`.
 
-In addition, please note that the command will add Solidus Auth Devise
-frontend components to your app. At the moment, you will need to manually
-remove the gem and its frontend components if you don't need them.
+You can also choose to skip installing the Solidus Auth Devise frontend components
+to your app by running `solidus_starter_frontend --skip-authentication`.
 
 Finally, please note that you won't be able to auto-update the storefront code
 with the next versions released since this project's gem will not be present in

--- a/app/controllers/spree/checkout_controller.rb
+++ b/app/controllers/spree/checkout_controller.rb
@@ -270,10 +270,6 @@ module Spree
       %w(registration update_registration).include?(params[:action])
     end
 
-    def check_authorization
-      authorize!(:edit, current_order, cookies.signed[:guest_token])
-    end
-
     # Introduces a registration step whenever the +registration_step+ preference is true.
     def check_registration
       return unless registration_required?

--- a/app/controllers/spree/checkout_controller.rb
+++ b/app/controllers/spree/checkout_controller.rb
@@ -192,6 +192,11 @@ module Spree
       end
     end
 
+    # Provides a route to redirect after order completion
+    def completion_route
+      spree.order_path(@order)
+    end
+
     def setup_for_current_state
       method_name = :"before_#{@order.state}"
       send(method_name) if respond_to?(method_name, true)
@@ -232,6 +237,10 @@ module Spree
       flash.now[:error] = t('spree.spree_gateway_error_flash_for_checkout')
       @order.errors.add(:base, exception.message)
       render :edit
+    end
+
+    def check_authorization
+      authorize!(:edit, current_order, cookies.signed[:guest_token])
     end
 
     def insufficient_stock_error

--- a/app/controllers/spree/checkout_controller.rb
+++ b/app/controllers/spree/checkout_controller.rb
@@ -16,14 +16,16 @@ module Spree
     before_action :ensure_valid_state
 
     before_action :associate_user
-    before_action :check_registration, except: [:registration, :update_registration]
+    before_action :check_registration, except: [:registration, :update_registration] # SolidusStarterFrontendGenerator/with-authentication/line
     before_action :check_authorization
 
     before_action :setup_for_current_state, only: [:edit, :update]
 
+    # SolidusStarterFrontendGenerator/with-authentication/start
     # This action builds some associations on the order, ex. addresses, which we
     # don't need to build or save here.
     skip_before_action :setup_for_current_state, only: [:registration, :update_registration]
+    # SolidusStarterFrontendGenerator/with-authentication/end
 
     helper 'spree/orders'
 
@@ -52,6 +54,8 @@ module Spree
       end
     end
 
+    # SolidusStarterFrontendGenerator/with-authentication/start
+
     def registration
       @user = Spree::User.new
     end
@@ -65,6 +69,8 @@ module Spree
         render 'registration'
       end
     end
+
+    # SolidusStarterFrontendGenerator/with-authentication/end
 
     private
 
@@ -249,6 +255,8 @@ module Spree
       end
     end
 
+    # SolidusStarterFrontendGenerator/without-authentication/start
+
     # Should be overriden if you have areas of your checkout that don't match
     # up to a step within checkout_steps, such as a registration step
     def skip_state_validation?
@@ -259,6 +267,10 @@ module Spree
     def completion_route
       spree.order_path(@order)
     end
+
+    # SolidusStarterFrontendGenerator/without-authentication/end
+
+    # SolidusStarterFrontendGenerator/with-authentication/start
 
     def order_params
       params.
@@ -299,5 +311,7 @@ module Spree
 
       spree.token_order_path(@order, @order.guest_token)
     end
+
+    # SolidusStarterFrontendGenerator/with-authentication/end
   end
 end

--- a/app/controllers/spree/checkout_controller.rb
+++ b/app/controllers/spree/checkout_controller.rb
@@ -152,12 +152,6 @@ module Spree
       end
     end
 
-    # Should be overriden if you have areas of your checkout that don't match
-    # up to a step within checkout_steps, such as a registration step
-    def skip_state_validation?
-      false
-    end
-
     def load_order
       @order = current_order
       redirect_to(spree.cart_path) && return unless @order
@@ -190,11 +184,6 @@ module Spree
         flash[:error] = t('spree.inventory_error_flash_for_insufficient_quantity', names: out_of_stock_items)
         redirect_to spree.cart_path
       end
-    end
-
-    # Provides a route to redirect after order completion
-    def completion_route
-      spree.order_path(@order)
     end
 
     def setup_for_current_state
@@ -258,6 +247,17 @@ module Spree
           redirect_to spree.checkout_state_path(@order.state)
         end
       end
+    end
+
+    # Should be overriden if you have areas of your checkout that don't match
+    # up to a step within checkout_steps, such as a registration step
+    def skip_state_validation?
+      false
+    end
+
+    # Provides a route to redirect after order completion
+    def completion_route
+      spree.order_path(@order)
     end
 
     def order_params

--- a/app/views/spree/components/layout/_top_bar.html.erb
+++ b/app/views/spree/components/layout/_top_bar.html.erb
@@ -3,6 +3,6 @@
   <div class="top-bar__search">
     <%= render partial: 'spree/components/search/search_bar' %>
   </div>
-  <%= render partial: 'spree/components/navigation/auth_link' %>
+  <%= render partial: 'spree/components/navigation/auth_link' %><%# SolidusStarterFrontendGenerator/with-authentication/line %>
   <%= render partial: 'spree/components/cart/cart_link' %>
 </div>

--- a/bin/sandbox
+++ b/bin/sandbox
@@ -50,6 +50,16 @@ else
   rspec_rails_gem_line="gem 'rspec-rails', groups: [:development, :test]"
 fi
 
+if [[ "${SANDBOX_SKIP_AUTHENTICATION}" == '1' ]]; then
+  generator_skip_authentication_argument='--skip-authentication'
+  solidus_auth_devise_gem_line=''
+  solidus_install_user_class_argument=""
+else
+  generator_skip_authentication_argument=''
+  solidus_auth_devise_gem_line="gem 'solidus_auth_devise'"
+  solidus_install_user_class_argument="--user_class=Spree::User"
+fi
+
 rm -rf "${sandbox_path}"
 bundle exec rails new "${sandbox_name}" --database="${railsdb}" \
   --skip-bundle \
@@ -84,7 +94,7 @@ gem 'solidus_i18n', github: solidus_i18n_repo, branch: solidus_i18n_branch
 
 gem 'rails-i18n'
 ${extension_gem_line}
-gem 'solidus_auth_devise'
+${solidus_auth_devise_gem_line}
 
 ${rspec_rails_gem_line}
 RUBY
@@ -123,16 +133,21 @@ bundle exec rake db:drop db:create
 
 bundle exec rails generate solidus:install \
   --auto-accept \
-  --user_class=Spree::User \
+  "${solidus_install_user_class_argument}" \
   --enforce_available_locales=true \
   --with-authentication=false \
   --payment-method=none \
   "$@"
 
-bundle exec rails generate solidus:auth:install --auto-run-migrations
+if [[ "${SANDBOX_SKIP_AUTHENTICATION}" != '1' ]]; then
+  bundle exec rails generate solidus:auth:install --auto-run-migrations
+fi
 
 if [[ -n "${GENERATE_FRONTEND}" ]]; then
-  bundle exec "${extension_name}" --auto-accept "${generator_skip_specs_argument}"
+  bundle exec "${extension_name}" \
+    --auto-accept \
+    "${generator_skip_specs_argument}" \
+    "${generator_skip_authentication_argument}"
 else
   if [[ -z "${SKIP_SPECS}" ]]; then
     bundle exec rails g solidus_starter_frontend:rspec

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,8 @@
 Spree::Core::Engine.routes.draw do
   root to: 'home#index'
 
+  # SolidusStarterFrontendGenerator/with-authentication/start
+
   devise_for(:spree_user, {
     class_name: 'Spree::User',
     controllers: {
@@ -34,14 +36,20 @@ Spree::Core::Engine.routes.draw do
 
   resource :account, controller: 'users'
 
+  # SolidusStarterFrontendGenerator/with-authentication/end
+
   resources :products, only: [:index, :show]
 
   get '/locale/set', to: 'locale#set'
   post '/locale/set', to: 'locale#set', as: :select_locale
 
   # non-restful checkout stuff
+
+  # SolidusStarterFrontendGenerator/with-authentication/start
   get '/checkout/registration', to: 'checkout#registration', as: :checkout_registration
   put '/checkout/registration', to: 'checkout#update_registration', as: :update_checkout_registration
+  # SolidusStarterFrontendGenerator/with-authentication/end
+
   patch '/checkout/update/:state', to: 'checkout#update', as: :update_checkout
   get '/checkout/:state', to: 'checkout#edit', as: :checkout_state
   get '/checkout', to: 'checkout#edit', as: :checkout

--- a/lib/generators/solidus_starter_frontend/disable_code.rb
+++ b/lib/generators/solidus_starter_frontend/disable_code.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require_relative 'marker_namespace'
+
+module SolidusStarterFrontend
+  class DisableCode
+    attr_reader :generator, :namespace, :path
+
+    def initialize(generator:, namespace:, path:)
+      @generator = generator
+      @namespace = namespace
+      @path = path
+    end
+
+    def call
+      delete_lines
+      delete_blocks
+    end
+
+    private
+
+    def delete_lines
+      marker_namespace.line_markers.each do |line_marker|
+        generator.gsub_file path, /.*#{line_marker}\n?/, ''
+      end
+    end
+
+    def delete_blocks
+      non_greedy_content_regex_string = "(?:.*?)"
+
+      marker_namespace.block_marker_pairs.each do |block_marker_pair|
+        delete_block_regex_string =
+          "(?: *)#{block_marker_pair[:start]}" +
+          non_greedy_content_regex_string +
+          "#{block_marker_pair[:end]}\n?"
+
+        delete_block_regex =
+          Regexp.new(delete_block_regex_string, Regexp::MULTILINE)
+
+        generator.gsub_file path, delete_block_regex, ""
+      end
+    end
+
+    def marker_namespace
+      @marker_namespace ||= MarkerNamespace.new(namespace)
+    end
+  end
+end

--- a/lib/generators/solidus_starter_frontend/enable_code.rb
+++ b/lib/generators/solidus_starter_frontend/enable_code.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require_relative 'marker_namespace'
+
+module SolidusStarterFrontend
+  class EnableCode
+    attr_reader :generator, :namespace, :path
+
+    def initialize(generator:, namespace:, path:)
+      @generator = generator
+      @namespace = namespace
+      @path = path
+    end
+
+    def call
+      uncomment_ruby_lines
+      uncomment_ruby_blocks
+    end
+
+    private
+
+    def uncomment_ruby_lines
+      generator.gsub_file path, /# (.*?) #{marker_namespace.ruby_line_comment}/, '\1'
+    end
+
+    def uncomment_ruby_blocks
+      non_greedy_content = "(.*?)"
+
+      uncomment_block_regex_string =
+        "#{marker_namespace.ruby_block_comment_start}\n" +
+        non_greedy_content +
+        "#{marker_namespace.ruby_block_comment_end}\n?"
+
+      uncomment_block_regex = Regexp.new(uncomment_block_regex_string, Regexp::MULTILINE)
+
+      generator.gsub_file path, uncomment_block_regex, '\1'
+    end
+
+    def marker_namespace
+      @marker_namespace ||= MarkerNamespace.new(namespace)
+    end
+  end
+end

--- a/lib/generators/solidus_starter_frontend/marker_namespace.rb
+++ b/lib/generators/solidus_starter_frontend/marker_namespace.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module SolidusStarterFrontend
+  class MarkerNamespace
+    attr_reader :namespace
+
+    def initialize(namespace)
+      @namespace = namespace
+    end
+
+    def line_markers
+      [
+        "<%# #{marker_name('line')} %>",
+        ruby_line_comment
+      ]
+    end
+
+    def ruby_line_comment
+      "# #{marker_name('line')}"
+    end
+
+    def block_marker_pairs
+      [
+        erb_marker_pair,
+        ruby_block_comment_pair,
+        ruby_line_comment_pair
+      ]
+    end
+
+    def erb_marker_pair
+      { start: "<%# #{marker_name('start')} %>", end: "<%# #{marker_name('end')} %>" }
+    end
+
+    def ruby_line_comment_pair
+      { start: "# #{marker_name('start')}", end: "# #{marker_name('end')}" }
+    end
+
+    def ruby_block_comment_pair
+      { start: ruby_block_comment_start, end: ruby_block_comment_end }
+    end
+
+    def ruby_block_comment_start
+      "=begin # #{marker_name('start')}"
+    end
+
+    def ruby_block_comment_end
+      "=end # #{marker_name('end')}"
+    end
+
+    def marker_name(name)
+      [namespace, name].join('/')
+    end
+  end
+end

--- a/lib/generators/solidus_starter_frontend/remove_markers.rb
+++ b/lib/generators/solidus_starter_frontend/remove_markers.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require_relative 'marker_namespace'
+
+module SolidusStarterFrontend
+  class RemoveMarkers
+    attr_reader :generator, :namespace, :path
+
+    def initialize(generator:, namespace:, path:)
+      @generator = generator
+      @namespace = namespace
+      @path = path
+    end
+
+    def call
+      remove_line_markers
+      remove_block_markers
+    end
+
+    private
+
+    def remove_line_markers
+      marker_namespace.line_markers.each do |line_marker|
+        generator.gsub_file path, /(?: ?)#{line_marker}/, ''
+      end
+    end
+
+    def remove_block_markers
+      [marker_namespace.erb_marker_pair, marker_namespace.ruby_line_comment_pair].each do |pair|
+        generator.gsub_file path, /(?: *)#{pair[:start]}\n?/, ''
+        generator.gsub_file path, /(?: *)#{pair[:end]}\n?/, ''
+      end
+    end
+
+    def marker_namespace
+      @marker_namespace ||= MarkerNamespace.new(namespace)
+    end
+  end
+end

--- a/lib/generators/solidus_starter_frontend/rspec_generator.rb
+++ b/lib/generators/solidus_starter_frontend/rspec_generator.rb
@@ -1,8 +1,41 @@
 # frozen_string_literal: true
 
+require_relative 'enable_code'
+require_relative 'disable_code'
+require_relative 'remove_markers'
+
 module SolidusStarterFrontend
   class RspecGenerator < Rails::Generators::Base
+    PATHS_WITH_AUTHENTICATION_CODE = [
+      'spec/controllers/controller_helpers_spec.rb',
+      'spec/requests/spree/orders_ability_spec.rb',
+      'spec/solidus_starter_frontend_helper.rb',
+      'spec/support/solidus_starter_frontend/system_helpers.rb',
+      'spec/system/checkout_spec.rb'
+    ]
+
+    PATHS_WITH_NON_AUTHENTICATION_CODE = [
+      'spec/solidus_starter_frontend_helper.rb',
+      'spec/requests/spree/orders_ability_spec.rb',
+      'spec/system/checkout_spec.rb'
+    ]
+
+    AUTHENTICATION_PATHS = [
+      'spec/controllers/spree/base_controller_spec.rb',
+      'spec/controllers/spree/checkout_controller_spec.rb',
+      'spec/controllers/spree/products_controller_spec.rb',
+      'spec/controllers/spree/user_passwords_controller_spec.rb',
+      'spec/controllers/spree/user_registrations_controller_spec.rb',
+      'spec/controllers/spree/users_controller_spec.rb',
+      'spec/controllers/spree/user_sessions_controller_spec.rb',
+      'spec/mailers/user_mailer_spec.rb',
+      'spec/support/solidus_starter_frontend/features/fill_addresses_fields.rb',
+      'spec/system/authentication'
+    ]
+
     source_root File.expand_path('../../..', __dir__)
+
+    class_option 'skip-authentication', type: :boolean, default: false
 
     def install
       gem_group :development, :test do
@@ -17,14 +50,71 @@ module SolidusStarterFrontend
       end
 
       # Copy spec files
-      directory 'spec/controllers'
+      directory 'spec/controllers', exclude_pattern: exclude_authentication_paths_pattern
       directory 'spec/helpers'
-      directory 'spec/mailers'
+      directory 'spec/mailers', exclude_pattern: exclude_authentication_paths_pattern
       directory 'spec/requests'
-      directory 'spec/support/solidus_starter_frontend'
-      directory 'spec/system'
+      directory 'spec/support/solidus_starter_frontend', exclude_pattern: exclude_authentication_paths_pattern
+      directory 'spec/system', exclude_pattern: exclude_authentication_paths_pattern
       directory 'spec/views'
       copy_file 'spec/solidus_starter_frontend_helper.rb'
+
+      if include_authentication?
+        PATHS_WITH_AUTHENTICATION_CODE.each do |path|
+          SolidusStarterFrontend::EnableCode.new(
+            generator: self,
+            namespace: 'RspecGenerator/with-authentication',
+            path: path
+          ).call
+
+          SolidusStarterFrontend::RemoveMarkers.new(
+            generator: self,
+            namespace: 'RspecGenerator/with-authentication',
+            path: path
+          ).call
+        end
+
+        PATHS_WITH_NON_AUTHENTICATION_CODE.each do |path|
+          SolidusStarterFrontend::DisableCode.new(
+            generator: self,
+            namespace: 'RspecGenerator/without-authentication',
+            path: path
+          ).call
+        end
+      else
+        PATHS_WITH_NON_AUTHENTICATION_CODE.each do |path|
+          SolidusStarterFrontend::EnableCode.new(
+            generator: self,
+            namespace: 'RspecGenerator/without-authentication',
+            path: path
+          ).call
+
+          SolidusStarterFrontend::RemoveMarkers.new(
+            generator: self,
+            namespace: 'RspecGenerator/without-authentication',
+            path: path
+          ).call
+        end
+
+        PATHS_WITH_AUTHENTICATION_CODE.each do |path|
+          SolidusStarterFrontend::DisableCode.new(
+            generator: self,
+            namespace: 'RspecGenerator/with-authentication',
+            path: path
+          ).call
+        end
+      end
+    end
+
+    private
+
+    def include_authentication?
+      !options['skip-authentication']
+    end
+
+    def exclude_authentication_paths_pattern
+      @exclude_authentication_paths_pattern ||=
+        options['skip-authentication'] ? Regexp.new(AUTHENTICATION_PATHS.join('|')) : nil
     end
   end
 end

--- a/lib/generators/solidus_starter_frontend/solidus_starter_frontend_generator.rb
+++ b/lib/generators/solidus_starter_frontend/solidus_starter_frontend_generator.rb
@@ -1,20 +1,50 @@
 # frozen_string_literal: true
 
 require 'bundler'
+require_relative 'enable_code'
+require_relative 'disable_code'
+require_relative 'remove_markers'
 
 class SolidusStarterFrontendGenerator < Rails::Generators::Base
+  PATHS_WITH_AUTHENTICATION_CODE = [
+    'app/controllers/spree/checkout_controller.rb',
+    'app/views/spree/components/layout/_top_bar.html.erb',
+    'config/routes.rb'
+  ]
+
+  PATHS_WITH_NON_AUTHENTICATION_CODE = [
+    'app/controllers/spree/checkout_controller.rb'
+  ]
+
+  AUTHENTICATION_PATHS = [
+      'app/controllers/spree/user_confirmations_controller.rb',
+      'app/controllers/spree/user_passwords_controller.rb',
+      'app/controllers/spree/user_registrations_controller.rb',
+      'app/controllers/spree/users_controller.rb',
+      'app/controllers/spree/user_sessions_controller.rb',
+      'app/decorators/spree/checkout_controller_decorator.rb',
+      'app/mailers/spree/user_mailer.rb',
+      'app/views/spree/checkout/registration.html.erb',
+      'app/views/spree/components/navigation/_auth_link.html.erb',
+      'app/views/spree/user_mailer',
+      'app/views/spree/user_passwords',
+      'app/views/spree/user_registrations',
+      'app/views/spree/users',
+      'app/views/spree/user_sessions'
+    ]
+
   source_root File.expand_path('../../..', __dir__)
 
   class_option 'skip-specs', type: :boolean, default: false
+  class_option 'skip-authentication', type: :boolean, default: false
 
   def install
     # Copy directories
-    directory 'app', 'app'
+    directory 'app', 'app', exclude_pattern: exclude_authentication_paths_pattern
 
     # Copy files
     copy_file 'lib/solidus_starter_frontend_configuration.rb'
     copy_file 'lib/solidus_starter_frontend/config.rb'
-    copy_file 'config/initializers/solidus_auth_devise_unauthorized_redirect.rb'
 
     # Routes
     copy_file 'config/routes.rb', 'tmp/routes.rb'
@@ -22,7 +52,7 @@ class SolidusStarterFrontendGenerator < Rails::Generators::Base
 
     # Gems
     gem 'canonical-rails'
-    gem 'solidus_auth_devise'
+    gem 'solidus_auth_devise' unless options['skip-authentication']
     gem 'solidus_support'
     gem 'truncate_html'
 
@@ -34,6 +64,55 @@ class SolidusStarterFrontendGenerator < Rails::Generators::Base
     append_file 'config/initializers/assets.rb', "Rails.application.config.assets.precompile += ['solidus_starter_frontend_manifest.js']"
     inject_into_file 'config/initializers/spree.rb', "require_relative Rails.root.join('lib/solidus_starter_frontend/config')\n", before: /Spree.config do/, verbose: true
     gsub_file 'app/assets/stylesheets/application.css', '*= require_tree', '* OFF require_tree'
+
+    # Authentication
+    if include_authentication?
+      copy_file 'config/initializers/solidus_auth_devise_unauthorized_redirect.rb'
+
+      PATHS_WITH_AUTHENTICATION_CODE.each do |path|
+        SolidusStarterFrontend::EnableCode.new(
+          generator: self,
+          namespace: 'SolidusStarterFrontendGenerator/with-authentication',
+          path: path
+        ).call
+
+        SolidusStarterFrontend::RemoveMarkers.new(
+          generator: self,
+          namespace: 'SolidusStarterFrontendGenerator/with-authentication',
+          path: path
+        ).call
+      end
+
+      PATHS_WITH_NON_AUTHENTICATION_CODE.each do |path|
+        SolidusStarterFrontend::DisableCode.new(
+          generator: self,
+          namespace: 'SolidusStarterFrontendGenerator/without-authentication',
+          path: path
+        ).call
+      end
+    else
+      PATHS_WITH_NON_AUTHENTICATION_CODE.each do |path|
+        SolidusStarterFrontend::EnableCode.new(
+          generator: self,
+          namespace: 'SolidusStarterFrontendGenerator/without-authentication',
+          path: path
+        ).call
+
+        SolidusStarterFrontend::RemoveMarkers.new(
+          generator: self,
+          namespace: 'SolidusStarterFrontendGenerator/without-authentication',
+          path: path
+        ).call
+      end
+
+      PATHS_WITH_AUTHENTICATION_CODE.each do |path|
+        SolidusStarterFrontend::DisableCode.new(
+          generator: self,
+          namespace: 'SolidusStarterFrontendGenerator/with-authentication',
+          path: path
+        ).call
+      end
+    end
 
     # Specs
     if include_specs?
@@ -47,12 +126,21 @@ class SolidusStarterFrontendGenerator < Rails::Generators::Base
       # see https://stackoverflow.com/a/12029262/65925 for more details.
       #
       # See also https://github.com/nebulab/solidus_starter_frontend/pull/174#discussion_r685626737.
-      invoke 'solidus_starter_frontend:rspec'
+      invoke 'solidus_starter_frontend:rspec', [], 'skip-authentication' => options['skip-authentication']
       invoke 'rspec:install'
     end
   end
 
   private
+
+  def include_authentication?
+    !options['skip-authentication']
+  end
+
+  def exclude_authentication_paths_pattern
+    @exclude_authentication_paths_pattern ||=
+      options['skip-authentication'] ? Regexp.new(AUTHENTICATION_PATHS.join('|')) : nil
+  end
 
   def include_specs?
     !options['skip-specs']

--- a/lib/generators/solidus_starter_frontend/solidus_starter_frontend_generator.rb
+++ b/lib/generators/solidus_starter_frontend/solidus_starter_frontend_generator.rb
@@ -35,6 +35,7 @@ class SolidusStarterFrontendGenerator < Rails::Generators::Base
     inject_into_file 'config/initializers/spree.rb', "require_relative Rails.root.join('lib/solidus_starter_frontend/config')\n", before: /Spree.config do/, verbose: true
     gsub_file 'app/assets/stylesheets/application.css', '*= require_tree', '* OFF require_tree'
 
+    # Specs
     if include_specs?
       # We can't use Rails' `generate` method here to call the generators. When
       # the solidus_starter_frontend generator is used as a standalone program

--- a/lib/generators/solidus_starter_frontend/solidus_starter_frontend_generator.rb
+++ b/lib/generators/solidus_starter_frontend/solidus_starter_frontend_generator.rb
@@ -35,7 +35,7 @@ class SolidusStarterFrontendGenerator < Rails::Generators::Base
     inject_into_file 'config/initializers/spree.rb', "require_relative Rails.root.join('lib/solidus_starter_frontend/config')\n", before: /Spree.config do/, verbose: true
     gsub_file 'app/assets/stylesheets/application.css', '*= require_tree', '* OFF require_tree'
 
-    unless options['skip-specs']
+    if include_specs?
       # We can't use Rails' `generate` method here to call the generators. When
       # the solidus_starter_frontend generator is used as a standalone program
       # (instead of added to an app's Gemfile), `generate` won't be able to pick
@@ -49,5 +49,11 @@ class SolidusStarterFrontendGenerator < Rails::Generators::Base
       invoke 'solidus_starter_frontend:rspec'
       invoke 'rspec:install'
     end
+  end
+
+  private
+
+  def include_specs?
+    !options['skip-specs']
   end
 end

--- a/spec/controllers/controller_helpers_spec.rb
+++ b/spec/controllers/controller_helpers_spec.rb
@@ -6,7 +6,7 @@ require 'solidus_starter_frontend_helper'
 # So we need to use one of the controllers inside Spree.
 # ProductsController is good.
 RSpec.describe Spree::ProductsController, type: :controller do
-  include Devise::Test::ControllerHelpers
+  include Devise::Test::ControllerHelpers # RspecGenerator/with-authentication/line
 
   before do
     I18n.enforce_available_locales = false

--- a/spec/generators/solidus_starter_frontend/disable_code_spec.rb
+++ b/spec/generators/solidus_starter_frontend/disable_code_spec.rb
@@ -1,0 +1,221 @@
+# frozen_string_literal: true
+
+require 'tempfile'
+require 'solidus_starter_frontend_helper'
+require 'generators/solidus_starter_frontend/disable_code.rb'
+
+module SolidusStarterFrontend
+  RSpec.describe DisableCode do
+    describe '#call' do
+      let(:generator_class) do
+        Class.new(Rails::Generators::Base) do
+        end
+      end
+
+      let(:generator) { generator_class.new([], quiet: true) }
+
+      let!(:tmp_file) do
+        Tempfile.new('disable_code_spec').tap do |file|
+          file.write(content)
+          file.close
+        end
+      end
+
+      let(:path) { tmp_file.path }
+
+      subject(:service) do
+        described_class.new(
+          generator: generator,
+          namespace: 'SampleGenerator',
+          path: path
+        )
+      end
+
+      describe 'concerning line markers' do
+        shared_examples 'can delete the line' do
+          context 'when a line is empty' do
+            let(:content) { '' }
+
+            it 'does nothing' do
+              service.call
+
+              expect(File.read(path)).to be_empty
+            end
+          end
+
+          context 'when a line does not have the marker' do
+            let(:content) { '# Not SampleGenerator/line' }
+
+            it 'does nothing' do
+              service.call
+
+              expect(File.read(path)).to eq(content)
+            end
+          end
+
+          context 'when a line only has the marker' do
+            let(:content) { marker }
+
+            it 'deletes the line' do
+              service.call
+
+              expect(File.read(path)).to be_empty
+            end
+          end
+
+          context 'when the marker has whitespace before it' do
+            let(:content) { " #{marker}" }
+
+            it 'deletes the line' do
+              service.call
+
+              expect(File.read(path)).to be_empty
+            end
+          end
+
+          context 'when the marker has content before it' do
+            let(:content) { "some content #{marker}" }
+
+            it 'deletes the line' do
+              service.call
+
+              expect(File.read(path)).to be_empty
+            end
+          end
+
+          context 'when the line before the marker has trailing whitespace' do
+            let(:content) { "preceding line \n#{marker}" }
+
+            it 'retains the whitespace' do
+              service.call
+
+              expect(File.read(path)).to eq("preceding line \n")
+            end
+          end
+
+          context 'when the line after the marker has leading whitespace' do
+            let(:content) { "#{marker}\n succeeding line" }
+
+            it 'retains the whitespace' do
+              service.call
+
+              expect(File.read(path)).to eq(" succeeding line")
+            end
+          end
+        end
+
+        context 'when the marker is a Ruby comment' do
+          let(:marker) { "# SampleGenerator/line" }
+
+          it_behaves_like 'can delete the line'
+        end
+
+        context 'when the marker is a ERB comment' do
+          let(:marker) { "<%# SampleGenerator/line %>" }
+
+          it_behaves_like 'can delete the line'
+        end
+      end
+
+      describe 'concerning block markers' do
+        shared_examples 'can delete blocks' do
+          let(:block_content) { 'Content' }
+
+          let(:block) { [block_start_marker, block_content, block_end_marker].join("\n") }
+
+          context 'when the content is empty' do
+            let(:content) { '' }
+
+            it 'does nothing' do
+              service.call
+
+              expect(File.read(path)).to be_empty
+            end
+          end
+
+          context 'when the content does not have a block' do
+            let(:content) { '# Not SampleGenerator/start' }
+
+            it 'does nothing' do
+              service.call
+
+              expect(File.read(path)).to eq(content)
+            end
+          end
+
+          context 'when the content only has the block' do
+            let(:content) { block }
+
+            it 'deletes the block' do
+              service.call
+
+              expect(File.read(path)).to be_empty
+            end
+          end
+
+          context 'when the start and end markers have spaces before them' do
+            let(:block) do
+              [
+                " #{block_start_marker}",
+                block_content,
+                " #{block_end_marker}"
+              ].join("\n")
+            end
+
+            let(:content) { block }
+
+            it 'deletes the whole block' do
+              service.call
+
+              expect(File.read(path)).to be_empty
+            end
+          end
+
+          context 'when the line before the block has trailing whitespace' do
+            let(:content) { "preceding line \n#{block}" }
+
+            it 'retains the whitespace' do
+              service.call
+
+              expect(File.read(path)).to eq("preceding line \n")
+            end
+          end
+
+          context 'when the line after the block has leading whitespace' do
+            let(:content) { "#{block}\n succeeding line" }
+
+            it 'retains the whitespace' do
+              service.call
+
+              expect(File.read(path)).to eq(" succeeding line")
+            end
+          end
+        end
+
+        context 'when the marker is a Ruby comment' do
+          let(:block_start_marker) do
+            '# SampleGenerator/start'
+          end
+
+          let(:block_end_marker) do
+            '# SampleGenerator/end'
+          end
+
+          it_behaves_like 'can delete blocks'
+        end
+
+        context 'when the marker is a multiline Ruby comment' do
+          let(:block_start_marker) do
+            '=begin # SampleGenerator/start'
+          end
+
+          let(:block_end_marker) do
+            '=end # SampleGenerator/end'
+          end
+
+          it_behaves_like 'can delete blocks'
+        end
+      end
+    end
+  end
+end

--- a/spec/generators/solidus_starter_frontend/enable_code_spec.rb
+++ b/spec/generators/solidus_starter_frontend/enable_code_spec.rb
@@ -1,0 +1,163 @@
+# frozen_string_literal: true
+
+require 'tempfile'
+require 'solidus_starter_frontend_helper'
+require 'generators/solidus_starter_frontend/enable_code.rb'
+
+module SolidusStarterFrontend
+  RSpec.describe EnableCode do
+    describe '#call' do
+      let(:generator_class) do
+        Class.new(Rails::Generators::Base) do
+        end
+      end
+
+      let(:generator) { generator_class.new([], quiet: true) }
+
+      let!(:tmp_file) do
+        Tempfile.new('enable_code_spec').tap do |file|
+          file.write(content)
+          file.close
+        end
+      end
+
+      let(:path) { tmp_file.path }
+
+      subject(:service) do
+        described_class.new(
+          generator: generator,
+          namespace: 'SampleGenerator',
+          path: path
+        )
+      end
+
+      describe 'concerning marked Ruby-commented lines' do
+        let(:marker) { "# SampleGenerator/line" }
+
+        context 'when a line is empty' do
+          let(:content) { '' }
+
+          it 'does nothing' do
+            service.call
+
+            expect(File.read(path)).to be_empty
+          end
+        end
+
+        context 'when a line does not have the marker' do
+          let(:content) { '# Not SampleGenerator/line' }
+
+          it 'does nothing' do
+            service.call
+
+            expect(File.read(path)).to eq(content)
+          end
+        end
+
+        context 'when the marker has a comment before it' do
+          let(:content) { "# some commented code #{marker}" }
+
+          it 'uncomments the line' do
+            service.call
+
+            expect(File.read(path)).to eq('some commented code')
+          end
+        end
+
+        context 'when the comment has whitespace before it' do
+          let(:content) { " # some commented code #{marker}" }
+
+          it 'retains the whitespace before the content' do
+            service.call
+
+            expect(File.read(path)).to eq(' some commented code')
+          end
+        end
+
+        context 'when the line before the comment has trailing whitespace' do
+          let(:content) { "preceding line \n# some commented code #{marker}" }
+
+          it 'retains the whitespace' do
+            service.call
+
+            expect(File.read(path)).to eq("preceding line \nsome commented code")
+          end
+        end
+
+        context 'when the line after the comment has leading whitespace' do
+          let(:content) { "# some commented code #{marker}\n succeeding line" }
+
+          it 'retains the whitespace' do
+            service.call
+
+            expect(File.read(path)).to eq("some commented code\n succeeding line")
+          end
+        end
+      end
+
+      describe 'concerning marked Ruby-commented blocks' do
+        let(:block_start_marker) do
+          '=begin # SampleGenerator/start'
+        end
+
+        let(:block_end_marker) do
+          '=end # SampleGenerator/end'
+        end
+
+        let(:block_content) { 'Content' }
+
+        let(:block) { [block_start_marker, block_content, block_end_marker].join("\n") }
+
+        context 'when the content is empty' do
+          let(:content) { '' }
+
+          it 'does nothing' do
+            service.call
+
+            expect(File.read(path)).to be_empty
+          end
+        end
+
+        context 'when the content does not have a block' do
+          let(:content) { '# Not SampleGenerator/start' }
+
+          it 'does nothing' do
+            service.call
+
+            expect(File.read(path)).to eq(content)
+          end
+        end
+
+        context 'when the content only has the block' do
+          let(:content) { block }
+
+          it 'uncomments the block' do
+            service.call
+
+            expect(File.read(path)).to eq("#{block_content}\n")
+          end
+        end
+
+        context 'when the line before the block has trailing whitespace' do
+          let(:content) { "preceding line \n#{block}" }
+
+          it 'retains the whitespace' do
+            service.call
+
+            expect(File.read(path)).to eq("preceding line \n#{block_content}\n")
+          end
+        end
+
+        context 'when the line after the block has leading whitespace' do
+          let(:content) { "#{block}\n succeeding line" }
+
+          it 'retains the whitespace' do
+            service.call
+
+            expect(File.read(path)).to eq("#{block_content}\n succeeding line")
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/generators/solidus_starter_frontend/remove_markers_spec.rb
+++ b/spec/generators/solidus_starter_frontend/remove_markers_spec.rb
@@ -1,0 +1,231 @@
+# frozen_string_literal: true
+
+require 'tempfile'
+require 'solidus_starter_frontend_helper'
+require 'generators/solidus_starter_frontend/remove_markers.rb'
+
+module SolidusStarterFrontend
+  RSpec.describe RemoveMarkers do
+    describe '#call' do
+      let(:generator_class) do
+        Class.new(Rails::Generators::Base) do
+        end
+      end
+
+      let(:generator) { generator_class.new([], quiet: true) }
+
+      let!(:tmp_file) do
+        Tempfile.new('enable_code_spec').tap do |file|
+          file.write(content)
+          file.close
+        end
+      end
+
+      let(:path) { tmp_file.path }
+
+      subject(:service) do
+        described_class.new(
+          generator: generator,
+          namespace: 'SampleGenerator',
+          path: path
+        )
+      end
+
+      describe 'concerning marked uncommented lines' do
+        shared_examples 'can remove the marker' do
+          context 'when a line is empty' do
+            let(:content) { '' }
+
+            it 'does nothing' do
+              service.call
+
+              expect(File.read(path)).to be_empty
+            end
+          end
+
+          context 'when a line does not have the marker' do
+            let(:content) { '# Not SampleGenerator/line' }
+
+            it 'does nothing' do
+              service.call
+
+              expect(File.read(path)).to eq(content)
+            end
+          end
+
+          context 'when a line only has the marker' do
+            let(:content) { marker }
+
+            it 'deletes the line' do
+              service.call
+
+              expect(File.read(path)).to be_empty
+            end
+          end
+
+          context 'when the marker has whitespace before it' do
+            let(:content) { " #{marker}" }
+
+            it 'deletes the line' do
+              service.call
+
+              expect(File.read(path)).to be_empty
+            end
+          end
+
+          context 'when the marker has content before it' do
+            let(:content) { "some content #{marker}" }
+
+            it 'retains the content' do
+              service.call
+
+              expect(File.read(path)).to eq('some content')
+            end
+          end
+
+          context 'when the line before the marker has trailing whitespace' do
+            let(:content) { "preceding line \n#{marker}" }
+
+            it 'retains the whitespace' do
+              service.call
+
+              expect(File.read(path)).to eq("preceding line \n")
+            end
+          end
+
+          context 'when there is a line after the marker' do
+            let(:content) { "#{marker}\nsucceeding line" }
+
+            it 'retains the newline' do
+              service.call
+
+              expect(File.read(path)).to eq("\nsucceeding line")
+            end
+          end
+
+          context 'when the line after the marker has leading whitespace' do
+            let(:content) { "#{marker}\n succeeding line" }
+
+            it 'retains the whitespace' do
+              service.call
+
+              expect(File.read(path)).to eq("\n succeeding line")
+            end
+          end
+        end
+
+        context 'when the marker is a ERB comment' do
+          let(:marker) { "<%# SampleGenerator/line %>" }
+
+          it_behaves_like 'can remove the marker'
+        end
+
+        context 'when the marker is a Ruby comment' do
+          let(:marker) { "# SampleGenerator/line" }
+
+          it_behaves_like 'can remove the marker'
+        end
+      end
+
+      describe 'concerning marked uncommented blocks' do
+        shared_examples 'can remove the markers' do
+          let(:block_content) { 'Content' }
+
+          let(:block) { [block_start_marker, block_content, block_end_marker].join("\n") }
+
+          context 'when the content is empty' do
+            let(:content) { '' }
+
+            it 'does nothing' do
+              service.call
+
+              expect(File.read(path)).to be_empty
+            end
+          end
+
+          context 'when the content does not have a block' do
+            let(:content) { '# Not SampleGenerator/start' }
+
+            it 'does nothing' do
+              service.call
+
+              expect(File.read(path)).to eq(content)
+            end
+          end
+
+          context 'when the content only has the block' do
+            let(:content) { block }
+
+            it 'removes the markers' do
+              service.call
+
+              expect(File.read(path)).to eq("#{block_content}\n")
+            end
+          end
+
+          context 'when the start and end markers have spaces before them' do
+            let(:block) do
+              [
+                " #{block_start_marker}",
+                block_content,
+                " #{block_end_marker}"
+              ].join("\n")
+            end
+
+            let(:content) { block }
+
+            it 'removes the markers' do
+              service.call
+
+              expect(File.read(path)).to eq("#{block_content}\n")
+            end
+          end
+
+          context 'when the line before the block has trailing whitespace' do
+            let(:content) { "preceding line \n#{block}" }
+
+            it 'retains the whitespace' do
+              service.call
+
+              expect(File.read(path)).to eq("preceding line \n#{block_content}\n")
+            end
+          end
+
+          context 'when the line after the block has leading whitespace' do
+            let(:content) { "#{block}\n succeeding line" }
+
+            it 'retains the whitespace' do
+              service.call
+
+              expect(File.read(path)).to eq("#{block_content}\n succeeding line")
+            end
+          end
+        end
+
+        context 'when the marker is a ERB comment' do
+          let(:block_start_marker) do
+            '<%# SampleGenerator/start %>'
+          end
+
+          let(:block_end_marker) do
+            '<%# SampleGenerator/end %>'
+          end
+
+          it_behaves_like 'can remove the markers'
+        end
+
+        context 'when the marker is a Ruby comment' do
+          let(:block_start_marker) do
+            '# SampleGenerator/start'
+          end
+
+          let(:block_end_marker) do
+            '# SampleGenerator/end'
+          end
+
+          it_behaves_like 'can remove the markers'
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/spree/orders_ability_spec.rb
+++ b/spec/requests/spree/orders_ability_spec.rb
@@ -17,35 +17,40 @@ RSpec.describe 'Order permissions', type: :request do
     context '#populate' do
       it 'checks if user is authorized for :update' do
         post spree.populate_orders_path, params: { variant_id: variant.id }
-        expect(response).to redirect_to(spree.login_path)
+        expect(response).to redirect_to(spree.login_path) # RspecGenerator/with-authentication/line
+        # expect(response).to redirect_to(:unauthorized) # RspecGenerator/without-authentication/line
       end
     end
 
     context '#edit' do
       it 'checks if user is authorized for :read' do
         get spree.cart_path
-        expect(response).to redirect_to(spree.login_path)
+        expect(response).to redirect_to(spree.login_path) # RspecGenerator/with-authentication/line
+        # expect(response).to redirect_to(:unauthorized) # RspecGenerator/without-authentication/line
       end
     end
 
     context '#update' do
       it 'checks if user is authorized for :update' do
         put spree.order_path(order.number), params: { order: { email: "foo@bar.com" } }
-        expect(response).to redirect_to(spree.login_path)
+        expect(response).to redirect_to(spree.login_path) # RspecGenerator/with-authentication/line
+        # expect(response).to redirect_to(:unauthorized) # RspecGenerator/without-authentication/line
       end
     end
 
     context '#empty' do
       it 'checks if user is authorized for :update' do
         put spree.empty_cart_path
-        expect(response).to redirect_to(spree.login_path)
+        expect(response).to redirect_to(spree.login_path) # RspecGenerator/with-authentication/line
+        # expect(response).to redirect_to(:unauthorized) # RspecGenerator/without-authentication/line
       end
     end
 
     context "#show" do
       it "checks against the specified order" do
         get spree.order_path(id: order.number)
-        expect(response).to redirect_to(spree.login_path)
+        expect(response).to redirect_to(spree.login_path) # RspecGenerator/with-authentication/line
+        # expect(response).to redirect_to(:unauthorized) # RspecGenerator/without-authentication/line
       end
     end
   end

--- a/spec/solidus_starter_frontend_helper.rb
+++ b/spec/solidus_starter_frontend_helper.rb
@@ -32,12 +32,28 @@ RSpec.configure do |config|
     config.include Spree::TestingSupport::Translations
   end
 
+  # RspecGenerator/with-authentication/start
+
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.include Devise::Test::IntegrationHelpers, type: :request
 
   config.before(:each, with_signed_in_user: true) do
     sign_in(user)
   end
+
+  # RspecGenerator/with-authentication/end
+
+=begin # RspecGenerator/without-authentication/start
+  config.before(:each, with_signed_in_user: true) do
+    Spree::StoreController.define_method(:spree_current_user) do
+      Spree.user_class.find_by(spree_api_key: 'fake api key')
+    end
+
+    allow(Spree.user_class).to receive(:find_by)
+      .with(hash_including(:spree_api_key))
+      .and_return(user)
+  end
+=end # RspecGenerator/without-authentication/end
 
   config.before(:each, with_guest_session: true) do
     allow_any_instance_of(ActionDispatch::Cookies::CookieJar).to receive(:signed) { { guest_token: order.guest_token } }

--- a/spec/support/solidus_starter_frontend/system_helpers.rb
+++ b/spec/support/solidus_starter_frontend/system_helpers.rb
@@ -2,9 +2,11 @@ module SystemHelpers
   def checkout_as_guest
     click_button "Checkout"
 
+    # RspecGenerator/with-authentication/start
     within '#guest_checkout' do
       fill_in 'Email', with: 'test@example.com'
     end
+    # RspecGenerator/with-authentication/end
 
     click_on 'Continue'
   end

--- a/spec/system/checkout_spec.rb
+++ b/spec/system/checkout_spec.rb
@@ -364,7 +364,8 @@ RSpec.describe 'Checkout', type: :system, inaccessible: true do
       click_on "Place Order"
 
       order = Spree::Order.last
-      expect(page).to have_current_path(spree.token_order_path(order, order.guest_token))
+      expect(page).to have_current_path(spree.token_order_path(order, order.guest_token)) # RspecGenerator/with-authentication/line
+      # expect(page).to have_current_path(spree.order_path(order)) # RspecGenerator/without-authentication/line
       expect(page).to have_content("Ending in #{credit_card.last_digits}")
     end
 
@@ -376,7 +377,8 @@ RSpec.describe 'Checkout', type: :system, inaccessible: true do
       click_on "Place Order"
 
       order = Spree::Order.last
-      expect(page).to have_current_path(spree.token_order_path(order, order.guest_token))
+      expect(page).to have_current_path(spree.token_order_path(order, order.guest_token)) # RspecGenerator/with-authentication/line
+      # expect(page).to have_current_path(spree.order_path(order)) # RspecGenerator/without-authentication/line
       expect(page).to have_content('Ending in 1111')
     end
   end
@@ -408,7 +410,8 @@ RSpec.describe 'Checkout', type: :system, inaccessible: true do
       click_on "Place Order"
 
       order = Spree::Order.last
-      expect(page).to have_current_path(spree.token_order_path(order, order.guest_token))
+      expect(page).to have_current_path(spree.token_order_path(order, order.guest_token)) # RspecGenerator/with-authentication/line
+      # expect(page).to have_current_path(spree.order_path(order)) # RspecGenerator/without-authentication/line
     end
   end
 
@@ -621,6 +624,7 @@ RSpec.describe 'Checkout', type: :system, inaccessible: true do
         add_mug_to_cart
         visit spree.checkout_state_path(:address)
 
+        # RspecGenerator/with-authentication/start
         # Unlike with the other examples in this spec, calling
         # `checkout_as_guest` in this example causes this example to fail
         # intermittently. Please see
@@ -631,6 +635,7 @@ RSpec.describe 'Checkout', type: :system, inaccessible: true do
           fill_in 'Password:', with: user.password
           click_button 'Login'
         end
+        # RspecGenerator/with-authentication/end
 
         fill_in_address
         fill_in 'Customer E-Mail', with: 'test@example.com'


### PR DESCRIPTION
Dependencies
----

Depends on https://github.com/nebulab/solidus_starter_frontend/pull/183. This is currently on Draft mode until that PR is merged.  

Goal
----

As a solidus_starter_frontend user

I want solidus_starter_frontend to have an option to run without generating the
authentication component

So that I can choose to exclude the authentication component if I don't need it
or if I want to implement it in another way.

Done
----

* Update CI - Add run-specs-with-postgres-for-generators and
  run-specs-with-postgres-skipping-authentication jobs.

* bin/sandbox - Respond to SANDBOX_SKIP_AUTHENTICATION environment variable.

* SolidusStarterFrontendGenerator and RspecGenerator - Add
  `--skip-authentication` options.

* Introduce EnableCode, DisableCode, and RemoveMarkers services.

* Identify and mark authentication-related and non-authentication-related files
  and code.

Implementation trade-offs
-------------------------

* Chose to keep marker detection strict in order to keep their corresponding
  regex matchers simple. For example, markers are assumed to have no trailing
  whitespace.

* Chose to surround markers with blank lines in order to improve readability.
  This results in some duplicate blank lines after the generators are ran.
  Fixing these blank lines would result in more complicated regex matchers. As
  such, I believe more sophisticated linters such as RuboCop would be better
  suited for fixing these duplicate blank lines.

Known limitations
-----------------

* The `EnableCode` service can only enable uncomment Ruby (`*.rb`) files. It
  doesn't handle ERB files yet, since we currently don't have ERB code that
  require uncommenting.

## Walkthrough

https://www.loom.com/share/3c528a13c6cb485f9f6d2a150f53a8ad

## Manual tests

https://www.loom.com/share/e5dc1966bd6d4868ac733385332e46fc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- N/A - Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- N/A - Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
