### PR TITLE
Fix: guest checkout registration error is not visible

### DIFF
--- a/templates/app/assets/stylesheets/spree/frontend/components/general/_flash.scss
+++ b/templates/app/assets/stylesheets/spree/frontend/components/general/_flash.scss
@@ -9,7 +9,8 @@
     background: $color-background-alert;
   }
 
-  &.error {
+  &.error,
+  &.registration_error {
     background: $color-background-error;
   }
 


### PR DESCRIPTION
Acceptance
----------

Given allow_guest_checkout is enabled
And I am not logged in
And I have an item in my cart
And I am in the cart page
When I try to check out
Then I should see the checkout registration page
And I should see the Checkout as a Guest form
When I leave the Email field in the form blank
And I click the Continue button of the form
Then I should see an error saying "Email address cannot be blank"

Bug description
---------------

The error message is not visible.

Cause
-----

The registration_error flash message does not have a background color. The background color is needed to contrast with the white color of the flash text.

## Screenshots (if appropriate):

Before fix:

![image](https://user-images.githubusercontent.com/61476/140034680-ef70f32b-ee75-4370-8be9-e41e08f5938b.png)

After fix:

![image](https://user-images.githubusercontent.com/61476/140034766-8e4f79a7-4bf8-436a-852d-8932d6a23c0e.png)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the code style of this project.