### PR TITLE
Move user error messages inside auth container

### DIFF
--- a/templates/app/views/spree/user_passwords/edit.html.erb
+++ b/templates/app/views/spree/user_passwords/edit.html.erb
@@ -1,7 +1,7 @@
-<%= render partial: 'spree/shared/error_messages', locals: { target: @spree_user } %>
-
 <article class="auth-container" id="change-password">
   <h1><%= I18n.t('spree.change_my_password') %></h1>
+
+  <%= render partial: 'spree/shared/error_messages', locals: { target: @spree_user } %>
 
   <%= render partial: 'spree/components/auth/change_form' %>
 </article>

--- a/templates/app/views/spree/user_registrations/new.html.erb
+++ b/templates/app/views/spree/user_registrations/new.html.erb
@@ -1,7 +1,7 @@
-<%= render 'spree/shared/error_messages', target: resource %>
-
 <article class="auth-container" id="new-customer">
   <h1><%= I18n.t('spree.new_customer') %></h1>
+
+  <%= render 'spree/shared/error_messages', target: resource %>
 
   <%= render partial: 'spree/components/auth/signup_form' %>
 </article>

--- a/templates/app/views/spree/users/edit.html.erb
+++ b/templates/app/views/spree/users/edit.html.erb
@@ -1,7 +1,7 @@
-<%= render partial: 'spree/shared/error_messages', locals: { target: @user } %>
-
 <article class="auth-container" id="edit-account">
   <h1><%= I18n.t('spree.editing_user') %></h1>
+
+  <%= render partial: 'spree/shared/error_messages', locals: { target: @user } %>
 
   <%= form_for Spree::User.new, as: @user, url: spree.user_path(@user), method: :put do |f| %>
     <div class="auth-form__input-wrapper">


### PR DESCRIPTION
## Bug description

Error explanation in user forms are not aligned with the form.

## Screenshots before fix:

### http://localhost:3000/signup

![image](https://user-images.githubusercontent.com/61476/140241114-1b7bc472-7d1f-403d-baca-954026c83b93.png)

### http://localhost:3000/password/change

![image](https://user-images.githubusercontent.com/61476/140241125-45017964-f1db-4a19-afba-167c7712c6f3.png)

### http://localhost:3000/account/edit

![image](https://user-images.githubusercontent.com/61476/140241162-9a5e505c-5ffd-4e6b-b386-b9bed23eb6bd.png)

## Screenshots after fix:

### http://localhost:3000/signup

![image](https://user-images.githubusercontent.com/61476/140240907-e1c32dcd-5fab-4461-ba22-f68090fde4ea.png)

### http://localhost:3000/password/change

![image](https://user-images.githubusercontent.com/61476/140241004-03c3e234-0fd7-4cb4-89bf-74bc8c144ee3.png)

### http://localhost:3000/account/edit

![image](https://user-images.githubusercontent.com/61476/140241040-60d26f2e-87dd-4227-9322-ca62fc58a1dc.png)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the code style of this project.
