### PR TITLE
Remove feature specs that test behavior already tested by component specs

### DIFF
--- a/templates/spec/system/products_spec.rb
+++ b/templates/spec/system/products_spec.rb
@@ -220,57 +220,17 @@ RSpec.describe 'Visiting Products', type: :system, inaccessible: true do
     expect(page.all('ul.products-grid li').size).to eq(0)
   end
 
-  context 'when filtering' do
-    before { visit spree.products_path }
+  it 'can filter products' do
+    visit spree.products_path
 
-    it 'should be able to display products priced under 10 dollars' do
-      within(:css, '.taxonomies') { click_link 'Ruby on Rails' }
-      check 'Price_Range_Under__10.00'
-      within(:css, '#sidebar_products_search') { click_button 'Search' }
-      expect(page).to have_content('No products found')
-    end
+    within(:css, '.taxonomies') { click_link 'Ruby on Rails' }
+    check 'Price_Range__15.00_-__18.00'
+    within(:css, '#sidebar_products_search') { click_button 'Search' }
 
-    it 'should be able to display products priced between 15 and 18 dollars' do
-      within(:css, '.taxonomies') { click_link 'Ruby on Rails' }
-      check 'Price_Range__15.00_-__18.00'
-      within(:css, '#sidebar_products_search') { click_button 'Search' }
+    product_names = page.all('ul.products-grid li a').map(&:text).flatten.reject(&:blank?).sort
 
-      expect(page.all('ul.products-grid li').size).to eq(3)
-      tmp = page.all('ul.products-grid li a').map(&:text).flatten.compact
-      tmp.delete('')
-      expect(tmp.sort!).to eq(
-        ['Ruby on Rails Mug', 'Ruby on Rails Stein', 'Ruby on Rails Tote']
-      )
-    end
-
-    it 'should be able to display products priced between 15 and 18 dollars across multiple pages' do
-      stub_spree_preferences(products_per_page: 2)
-      within(:css, '.taxonomies') { click_link 'Ruby on Rails' }
-      check 'Price_Range__15.00_-__18.00'
-      within(:css, '#sidebar_products_search') { click_button 'Search' }
-
-      expect(page.all('ul.products-grid li').size).to eq(2)
-      products = page.all('ul.products-grid li a[itemprop=name]')
-      expect(products.count).to eq(2)
-
-      find('nav.pagination .next a').click
-      products = page.all('ul.products-grid li a[itemprop=name]')
-      expect(products.count).to eq(1)
-    end
-
-    it 'should be able to display products priced 18 dollars and above' do
-      within(:css, '.taxonomies') { click_link 'Ruby on Rails' }
-      check 'Price_Range__18.00_-__20.00'
-      check 'Price_Range__20.00_or_over'
-      within(:css, '#sidebar_products_search') { click_button 'Search' }
-      expect(page.all('ul.products-grid li').size).to eq(4)
-      tmp = page.all('ul.products-grid li a').map(&:text).flatten.compact
-      tmp.delete('')
-      expect(tmp.sort!).to eq(['Ruby on Rails Bag',
-                               'Ruby on Rails Baseball Jersey',
-                               'Ruby on Rails Jr. Spaghetti',
-                               'Ruby on Rails Ringer T-Shirt'])
-    end
+    expect(product_names)
+      .to eq(['Ruby on Rails Mug', 'Ruby on Rails Stein', 'Ruby on Rails Tote'])
   end
 
   it 'should be able to put a product without a description in the cart' do

--- a/templates/spec/system/taxons_spec.rb
+++ b/templates/spec/system/taxons_spec.rb
@@ -65,6 +65,11 @@ RSpec.describe 'viewing products', type: :system, inaccessible: true do
 
   context "taxon pages" do
     include_context "custom products"
+
+    let(:product_names) do
+      page.all('ul.products-grid li a').map(&:text).flatten.reject(&:blank?).sort
+    end
+
     before do
       visit spree.products_path
     end
@@ -72,66 +77,27 @@ RSpec.describe 'viewing products', type: :system, inaccessible: true do
     it "should be able to visit brand Ruby on Rails" do
       within(:css, '.taxonomies') { click_link "Ruby on Rails" }
 
-      expect(page.all('ul.products-grid li').size).to eq(7)
-      tmp = page.all('ul.products-grid li a').map(&:text).flatten.compact
-      tmp.delete("")
-      array = ["Ruby on Rails Bag",
-               "Ruby on Rails Baseball Jersey",
-               "Ruby on Rails Jr. Spaghetti",
-               "Ruby on Rails Mug",
-               "Ruby on Rails Ringer T-Shirt",
-               "Ruby on Rails Stein",
-               "Ruby on Rails Tote"]
-      expect(tmp.sort!).to eq(array)
-    end
-
-    it "should be able to visit brand Ruby" do
-      within(:css, '.taxonomies') { click_link "Ruby" }
-
-      expect(page.all('ul.products-grid li').size).to eq(1)
-      tmp = page.all('ul.products-grid li a').map(&:text).flatten.compact
-      tmp.delete("")
-      expect(tmp.sort!).to eq(["Ruby Baseball Jersey"])
-    end
-
-    it "should be able to visit brand Apache" do
-      within(:css, '.taxonomies') { click_link "Apache" }
-
-      expect(page.all('ul.products-grid li').size).to eq(1)
-      tmp = page.all('ul.products-grid li a').map(&:text).flatten.compact
-      tmp.delete("")
-      expect(tmp.sort!).to eq(["Apache Baseball Jersey"])
+      expect(product_names).to contain_exactly(
+        "Ruby on Rails Bag",
+        "Ruby on Rails Baseball Jersey",
+        "Ruby on Rails Jr. Spaghetti",
+        "Ruby on Rails Mug",
+        "Ruby on Rails Ringer T-Shirt",
+        "Ruby on Rails Stein",
+        "Ruby on Rails Tote"
+      )
     end
 
     it "should be able to visit category Clothing" do
       click_link "Clothing"
 
-      expect(page.all('ul.products-grid li').size).to eq(5)
-      tmp = page.all('ul.products-grid li a').map(&:text).flatten.compact
-      tmp.delete("")
-      expect(tmp.sort!).to eq(["Apache Baseball Jersey",
-                               "Ruby Baseball Jersey",
-                               "Ruby on Rails Baseball Jersey",
-                               "Ruby on Rails Jr. Spaghetti",
-                               "Ruby on Rails Ringer T-Shirt"])
-    end
-
-    it "should be able to visit category Mugs" do
-      click_link "Mugs"
-
-      expect(page.all('ul.products-grid li').size).to eq(2)
-      tmp = page.all('ul.products-grid li a').map(&:text).flatten.compact
-      tmp.delete("")
-      expect(tmp.sort!).to eq(["Ruby on Rails Mug", "Ruby on Rails Stein"])
-    end
-
-    it "should be able to visit category Bags" do
-      click_link "Bags"
-
-      expect(page.all('ul.products-grid li').size).to eq(2)
-      tmp = page.all('ul.products-grid li a').map(&:text).flatten.compact
-      tmp.delete("")
-      expect(tmp.sort!).to eq(["Ruby on Rails Bag", "Ruby on Rails Tote"])
+      expect(product_names).to contain_exactly(
+        "Apache Baseball Jersey",
+        "Ruby Baseball Jersey",
+        "Ruby on Rails Baseball Jersey",
+        "Ruby on Rails Jr. Spaghetti",
+        "Ruby on Rails Ringer T-Shirt"
+      )
     end
   end
 


### PR DESCRIPTION
## Blockers 

Depends on https://github.com/nebulab/solidus_starter_frontend/pull/206 to be merged first.

## Goal

As a Solidus Starter Frontend user
I want to remove feature specs that test behavior already tested by component specs
So that we have less specs to maintain

## Background

See https://github.com/nebulab/solidus_starter_frontend/pull/203#issuecomment-967754589

## Types of changes

- N/A: Bug fix (non-breaking change which fixes an issue)
- N/A: New feature (non-breaking change which adds functionality)
- N/A: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- N/A: My change requires a change to the documentation.
- N/A: I have updated the documentation accordingly.
