### PR TITLE
Refactor cart forms

### DIFF
--- a/templates/app/views/spree/orders/_cart_footer.html.erb
+++ b/templates/app/views/spree/orders/_cart_footer.html.erb
@@ -1,10 +1,12 @@
+<% order = order_form.object %>
+
 <footer class="cart-footer">
   <p class="cart-footer__total">
     <%= t('spree.total') %>: <strong><%= order.display_total %></strong>
   </p>
 
   <div class="cart-footer__primary-action">
-    <%= button_tag(
+    <%= order_form.button(
       I18n.t('spree.checkout'),
       class: 'button-primary',
       id: 'checkout-link',

--- a/templates/app/views/spree/orders/_cart_header.html.erb
+++ b/templates/app/views/spree/orders/_cart_header.html.erb
@@ -4,7 +4,7 @@
   </h1>
 
   <div class="cart-header__actions">
-    <%= button_tag(
+    <%= order_form.button(
       t("spree.update"),
       class: 'button-primary button-primary--bordered button-primary--small',
       id: 'update-button'

--- a/templates/app/views/spree/orders/_cart_item.html.erb
+++ b/templates/app/views/spree/orders/_cart_item.html.erb
@@ -34,7 +34,7 @@
     </div>
 
     <div class="cart-item__remove">
-      <%= submit_tag(
+      <%= order_form.submit(
         'Remove',
         class: 'delete',
         id: "delete_#{dom_id(line_item)}",

--- a/templates/app/views/spree/orders/_cart_item.html.erb
+++ b/templates/app/views/spree/orders/_cart_item.html.erb
@@ -25,14 +25,8 @@
 
     <div class="cart-item__quantity">
       <div class="text-input">
-        <%= text_field_tag "order[line_items_attributes][#{item_form.options[:child_index]}][quantity]",
-          line_item.quantity,
-          type: :number,
-          id: "order_line_items_attributes_#{item_form.options[:child_index]}_quantity",
-          min: 0
-        %>
+        <%= item_form.text_field :quantity, type: 'number', min: 0 %>
       </div>
-
     </div>
 
     <div class="cart-item__price">

--- a/templates/app/views/spree/orders/edit.html.erb
+++ b/templates/app/views/spree/orders/edit.html.erb
@@ -6,7 +6,7 @@
   <% else %>
     <%= form_for @order, url: update_cart_path, html: {id: 'update-cart'} do |order_form| %>
       <% order = order_form.object %>
-      <%= render 'cart_header' %>
+      <%= render 'cart_header', order_form: order_form %>
       <%= render 'spree/shared/error_messages', target: order %>
       <%= render 'cart_items', order_form: order_form %>
       <%= render 'cart_footer', order: order %>

--- a/templates/app/views/spree/orders/edit.html.erb
+++ b/templates/app/views/spree/orders/edit.html.erb
@@ -9,7 +9,7 @@
       <%= render 'cart_header', order_form: order_form %>
       <%= render 'spree/shared/error_messages', target: order %>
       <%= render 'cart_items', order_form: order_form %>
-      <%= render 'cart_footer', order: order %>
+      <%= render 'cart_footer', order_form: order_form %>
     <% end %>
 
     <div class="cart-page__coupon-code">

--- a/templates/app/views/spree/products/_product_form.html.erb
+++ b/templates/app/views/spree/products/_product_form.html.erb
@@ -6,8 +6,8 @@
   }
 %>
 
-<%= form_for :order, url: populate_orders_path, html: schema_properties do |f| %>
-  <%= render 'product_variants', product: product %>
+<%= form_tag populate_orders_path, schema_properties do |f| %>
+  <%= render 'product_variants', product: product, form: f %>
 
   <% if product.price_for_options(current_pricing_options)&.money and !product.price.nil? %>
     <%= render 'product_submit', product: product %>

--- a/templates/app/views/spree/products/_product_form.html.erb
+++ b/templates/app/views/spree/products/_product_form.html.erb
@@ -7,10 +7,10 @@
 %>
 
 <%= form_for :order, url: populate_orders_path, html: schema_properties do |f| %>
-  <%= render 'product_variants' %>
+  <%= render 'product_variants', product: product %>
 
-  <% if @product.price_for_options(current_pricing_options)&.money and !@product.price.nil? %>
-    <%= render 'product_submit' %>
+  <% if product.price_for_options(current_pricing_options)&.money and !product.price.nil? %>
+    <%= render 'product_submit', product: product %>
   <% else %>
     <div id="product-price">
       <p data-js="price" itemprop="price">

--- a/templates/app/views/spree/products/_product_image.html.erb
+++ b/templates/app/views/spree/products/_product_image.html.erb
@@ -1,6 +1,6 @@
 <picture class="product-image">
   <%= render(ImageComponent.new(
-    image: @product.gallery.images.first,
+    image: product.gallery.images.first,
     size: :product,
     itemprop: "image",
     data: { js: 'product-main-image' }

--- a/templates/app/views/spree/products/_product_info.html.erb
+++ b/templates/app/views/spree/products/_product_info.html.erb
@@ -1,11 +1,11 @@
 <header class="product-info">
   <h1 class="product-info__title" itemprop="name">
-    <%= @product.name %>
+    <%= product.name %>
   </h1>
 
-  <%= render 'product_price', product: @product %>
+  <%= render 'product_price', product: product %>
 
   <p class="product-info__description" itemprop="description">
-    <%= product_description(@product) rescue t('spree.product_has_no_description') %>
+    <%= product_description(product) rescue t('spree.product_has_no_description') %>
   </p>
 </header>

--- a/templates/app/views/spree/products/_product_promotions.html.erb
+++ b/templates/app/views/spree/products/_product_promotions.html.erb
@@ -1,4 +1,4 @@
-<% promotions = @product.possible_promotions %>
+<% promotions = product.possible_promotions %>
 
 <% if promotions.any? %>
   <section class="product-promotions">

--- a/templates/app/views/spree/products/_product_properties.html.erb
+++ b/templates/app/views/spree/products/_product_properties.html.erb
@@ -1,4 +1,4 @@
-<% unless @product_properties.empty? %>
+<% unless product_properties.empty? %>
   <section class="product-properties">
     <h2 class="product-properties__title">
       <%= t('spree.properties')%>
@@ -6,7 +6,7 @@
 
     <table class="product-properties__table">
       <tbody>
-        <% @product_properties.each do |product_property| %>
+        <% product_properties.each do |product_property| %>
           <tr>
             <td><%= product_property.property.presentation %></td>
             <td><%= product_property.value %></td>

--- a/templates/app/views/spree/products/_product_submit.html.erb
+++ b/templates/app/views/spree/products/_product_submit.html.erb
@@ -1,5 +1,5 @@
 <div class="product-submit">
-  <%= render 'product_availability', product: @product %>
+  <%= render 'product_availability', product: product %>
 
   <div class="horizontal-input-group">
     <div class="horizontal-input-group__input">

--- a/templates/app/views/spree/products/_product_taxons.html.erb
+++ b/templates/app/views/spree/products/_product_taxons.html.erb
@@ -1,11 +1,11 @@
-<% if !@product.taxons.blank? %>
+<% if !product.taxons.blank? %>
   <section class="product-taxons">
     <h2 class="product-taxons__title">
       <%= t('spree.look_for_similar_items') %>:
     </h2>
 
     <ul class="product-taxons__list">
-      <% @product.taxons.each do |taxon| %>
+      <% product.taxons.each do |taxon| %>
         <li>
           <%= link_to taxon.name, seo_url(taxon) %>
         </li>

--- a/templates/app/views/spree/products/_product_thumbnails.html.erb
+++ b/templates/app/views/spree/products/_product_thumbnails.html.erb
@@ -1,8 +1,8 @@
-<% if @product.gallery.images.size > 1 %>
+<% if product.gallery.images.size > 1 %>
   <ul class="product-thumbnails">
-    <% @product.gallery.images.each do |image| %>
+    <% product.gallery.images.each do |image| %>
 
-      <% next if image.viewable_id != @product.master.id %>
+      <% next if image.viewable_id != product.master.id %>
       <%= content_tag(
         :li,
         class: 'product-thumbnails__all',
@@ -12,9 +12,9 @@
       <% end %>
     <% end %>
 
-    <% if @product.has_variants? %>
-      <% @product.gallery.images.each do |image| %>
-        <% next if image.viewable_id == @product.master.id %>
+    <% if product.has_variants? %>
+      <% product.gallery.images.each do |image| %>
+        <% next if image.viewable_id == product.master.id %>
         <%= content_tag(
           :li,
           class: 'product-thumbnails__variant',

--- a/templates/app/views/spree/products/_product_variants.html.erb
+++ b/templates/app/views/spree/products/_product_variants.html.erb
@@ -1,5 +1,5 @@
 <%
-  variants = @product.variants_and_option_values_for(current_pricing_options)
+  variants = product.variants_and_option_values_for(current_pricing_options)
 %>
 
 <% if variants.any? %>
@@ -32,5 +32,5 @@
     </ul>
   </section>
 <% else %>
-  <%= hidden_field_tag "variant_id", @product.master.id %>
+  <%= hidden_field_tag "variant_id", product.master.id %>
 <% end %>

--- a/templates/app/views/spree/products/show.html.erb
+++ b/templates/app/views/spree/products/show.html.erb
@@ -3,16 +3,16 @@
 <% cache [I18n.locale, current_pricing_options, @product] do %>
   <article class="product-page" itemscope itemtype="http://schema.org/Product">
     <div class="product-page__images">
-      <%= render 'product_image' %>
-      <%= render 'product_thumbnails' %>
+      <%= render 'product_image', product: @product %>
+      <%= render 'product_thumbnails', product: @product %>
     </div>
 
     <div class="product-page__info">
-      <%= render 'product_info' %>
-      <%= render 'product_promotions' %>
-      <%= render 'product_form' %>
-      <%= render 'product_properties' %>
-      <%= render 'product_taxons' %>
+      <%= render 'product_info', product: @product %>
+      <%= render 'product_promotions', product: @product %>
+      <%= render 'product_form', product: @product %>
+      <%= render 'product_properties', product_properties: @product_properties %>
+      <%= render 'product_taxons', product: @product %>
     </div>
   </article>
 <% end %>


### PR DESCRIPTION
## Blockers 

Depends on https://github.com/nebulab/solidus_starter_frontend/pull/206 to be merged first.

## Goal

As a Solidus Starter Frontend user
I want the cart forms to be refactored
So that the form helpers used will be consistent with their field helpers

## Screenshots

### Populate Cart form (http://localhost:3000/products/solidus-t-shirt)

![image](https://user-images.githubusercontent.com/61476/142156342-cd29bac3-34e4-4c61-bc52-6f2e3c0efa83.png)

### Checkout Shopping Cart form (http://localhost:3000/cart)

![image](https://user-images.githubusercontent.com/61476/142156880-a563ea38-642c-41e9-b409-7cc6e659d205.png)

## Types of changes

- N/A: Bug fix (non-breaking change which fixes an issue)
- N/A: New feature (non-breaking change which adds functionality)
- N/A: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- N/A: My change requires a change to the documentation.
- N/A: I have updated the documentation accordingly.
