### PR TITLE
Use form builder helpers for address step of checkout

### DIFF
--- a/templates/app/helpers/spree/solidus_starter_frontend_helper.rb
+++ b/templates/app/helpers/spree/solidus_starter_frontend_helper.rb
@@ -2,10 +2,6 @@
 
 module Spree
   module SolidusStarterFrontendHelper
-    def generate_address_id(form, input_name)
-      "#{form.object_name.gsub(/[\[\]]/, '[' => '_', ']' => '_')}#{input_name}"
-    end
-
     def generate_selected_shipping_rate_id(form, input_name, rate)
       "#{form.object_name.gsub(/[\[\]]/, '[' => '_', ']' => '_')}#{input_name}_#{rate.id}"
     end

--- a/templates/app/views/spree/checkout/_checkout_step.html.erb
+++ b/templates/app/views/spree/checkout/_checkout_step.html.erb
@@ -1,13 +1,8 @@
 <%= form_for order, url: update_checkout_path(order.state), html: { id: "checkout_form_#{order.state}" } do |form| %>
   <% if order.state == "address" || !order.email? %>
     <div class="text-input">
-      <%= label_tag 'order_email', 'Customer E-Mail:' %>
-      <%= text_field_tag 'order[email]',
-        order.email,
-        type: 'email',
-        required: true,
-        placeholder: 'name@example.com'
-      %>
+      <%= form.label :email, 'Customer E-Mail:' %>
+      <%= form.email_field :email, required: true, placeholder: 'name@example.com' %>
     </div>
   <% end %>
 

--- a/templates/app/views/spree/checkout/_checkout_step.html.erb
+++ b/templates/app/views/spree/checkout/_checkout_step.html.erb
@@ -1,9 +1,9 @@
-<%= form_for @order, url: update_checkout_path(@order.state), html: { id: "checkout_form_#{@order.state}" } do |form| %>
-  <% if @order.state == "address" || !@order.email? %>
+<%= form_for order, url: update_checkout_path(order.state), html: { id: "checkout_form_#{order.state}" } do |form| %>
+  <% if order.state == "address" || !order.email? %>
     <div class="text-input">
       <%= label_tag 'order_email', 'Customer E-Mail:' %>
       <%= text_field_tag 'order[email]',
-        @order.email,
+        order.email,
         type: 'email',
         required: true,
         placeholder: 'name@example.com'
@@ -11,5 +11,5 @@
     </div>
   <% end %>
 
-  <%= render "spree/checkout/steps/#{@order.state}_step", form: form %>
+  <%= render "spree/checkout/steps/#{order.state}_step", form: form %>
 <% end %>

--- a/templates/app/views/spree/checkout/edit.html.erb
+++ b/templates/app/views/spree/checkout/edit.html.erb
@@ -4,7 +4,7 @@
 
   <div class="checkout__main">
     <section class="checkout__step">
-      <%= render "checkout_step" %>
+      <%= render "checkout_step", order: @order %>
     </section>
 
     <% if @order.state != "confirm" %>

--- a/templates/app/views/spree/checkout/steps/_address_step.html.erb
+++ b/templates/app/views/spree/checkout/steps/_address_step.html.erb
@@ -1,3 +1,5 @@
+<% order = form.object %>
+
 <div class="address-step">
   <fieldset class="address-step__billing" id="billing">
     <legend>
@@ -9,7 +11,7 @@
         "spree/checkout/steps/address_step/address_inputs",
         form: bill_form,
         address_type: "billing",
-        address: @order.bill_address
+        address: order.bill_address
       ) %>
     <% end %>
   </fieldset>
@@ -21,7 +23,7 @@
 
     <%= form.fields_for :ship_address do |ship_form| %>
       <%= label_tag 'order_use_billing', class: 'checkbox-input' do %>
-        <%= check_box_tag('order[use_billing]', 1, @order.shipping_eq_billing_address?) %>
+        <%= check_box_tag('order[use_billing]', 1, order.shipping_eq_billing_address?) %>
         <%= t('spree.use_billing_address') %>
       <% end %>
 
@@ -29,7 +31,7 @@
         "spree/checkout/steps/address_step/address_inputs",
         form: ship_form,
         address_type: "shipping",
-        address: @order.ship_address
+        address: order.ship_address
        ) %>
     <% end %>
   </fieldset>

--- a/templates/app/views/spree/checkout/steps/_address_step.html.erb
+++ b/templates/app/views/spree/checkout/steps/_address_step.html.erb
@@ -37,7 +37,7 @@
   </fieldset>
 
   <div class="address-step__actions">
-    <%= button_tag(
+    <%= form.button(
       I18n.t("spree.save_and_continue"),
       class: 'button-primary',
       name: :commit

--- a/templates/app/views/spree/checkout/steps/address_step/_address_inputs.html.erb
+++ b/templates/app/views/spree/checkout/steps/address_step/_address_inputs.html.erb
@@ -22,16 +22,8 @@
   </div>
 
   <div class="text-input">
-    <% generate_address_id(form, "city").tap do |city_id| %>
-      <%= label_tag city_id, "#{I18n.t("spree.city")}:" %>
-
-      <%= text_field_tag "#{form.object_name}[city]",
-        address.city,
-        id: city_id,
-        required: true,
-        autocomplete: "#{address_type} address-level2"
-      %>
-    <% end %>
+    <%= form.label :city, "#{I18n.t("spree.city")}:" %>
+    <%= form.text_field :city, required: true, autocomplete: "#{address_type} address-level2" %>
   </div>
 
   <div class="select-input">

--- a/templates/app/views/spree/checkout/steps/address_step/_address_inputs.html.erb
+++ b/templates/app/views/spree/checkout/steps/address_step/_address_inputs.html.erb
@@ -1,16 +1,7 @@
 <div class="address-inputs">
   <div class="text-input">
-    <% generate_address_id(form, "name").tap do |name_id| %>
-      <%= label_tag name_id, "#{I18n.t("spree.name")}:" %>
-
-      <%= text_field_tag "#{form.object_name}[name]",
-        address.name,
-        id: name_id,
-        required: true,
-        autofocus: true,
-        autocomplete: "#{address_type} given-name"
-      %>
-    <% end %>
+    <%= form.label :name, "#{I18n.t("spree.name")}:" %>
+    <%= form.text_field :name, required: true, autofocus: true, autocomplete: "#{address_type} given-name" %>
   </div>
 
   <% if Spree::Config[:company] %>

--- a/templates/app/views/spree/checkout/steps/address_step/_address_inputs.html.erb
+++ b/templates/app/views/spree/checkout/steps/address_step/_address_inputs.html.erb
@@ -47,21 +47,19 @@
 
     <span class="js-address-fields" style="display: none;">
       <div class="select-input">
-        <% generate_address_id(form, "state_id").tap do |state_id| %>
-          <%= label_tag state_id, "#{I18n.t("spree.state")}:" %>
+        <%= form.label :state_id, "#{I18n.t("spree.state")}:" %>
 
-          <%= form.collection_select(
-            :state_id,
-            address.country.states,
-            :id,
-            :name,
-            { include_blank: true },
-            autocomplete: "#{address_type} address-level1",
-            class: 'required',
-            disabled: !have_states,
-            required: false
-          ) %>
-        <% end %>
+        <%= form.collection_select(
+          :state_id,
+          address.country.states,
+          :id,
+          :name,
+          { include_blank: true },
+          autocomplete: "#{address_type} address-level1",
+          class: 'required',
+          disabled: !have_states,
+          required: false
+        ) %>
       </div>
 
       <%= form.text_field(

--- a/templates/app/views/spree/checkout/steps/address_step/_address_inputs.html.erb
+++ b/templates/app/views/spree/checkout/steps/address_step/_address_inputs.html.erb
@@ -12,16 +12,8 @@
   <% end %>
 
   <div class="text-input">
-    <% generate_address_id(form, "address1").tap do |address1_id| %>
-      <%= label_tag address1_id, "#{I18n.t("spree.street_address")}:" %>
-
-      <%= text_field_tag "#{form.object_name}[address1]",
-        address.address1,
-        id: address1_id,
-        required: true,
-        autocomplete: "#{address_type} address-line1"
-      %>
-    <% end %>
+    <%= form.label :address1, "#{I18n.t("spree.street_address")}:" %>
+    <%= form.text_field :address1, required: true, autocomplete: "#{address_type} address-line1" %>
   </div>
 
   <div class="text-input">

--- a/templates/app/views/spree/checkout/steps/address_step/_address_inputs.html.erb
+++ b/templates/app/views/spree/checkout/steps/address_step/_address_inputs.html.erb
@@ -90,17 +90,12 @@
   </div>
 
   <div class="text-input">
-    <% generate_address_id(form, "phone").tap do |phone_id| %>
-      <%= label_tag phone_id, "#{I18n.t("spree.phone")}:" %>
+    <%= form.label :phone, "#{I18n.t("spree.phone")}:" %>
 
-      <%= text_field_tag "#{form.object_name}[phone]",
-        address.phone,
-        type: :tel,
-        id: phone_id,
-        required: address.require_phone?,
-        autocomplete: "#{address_type} home tel"
-      %>
-    <% end %>
+    <%= form.telephone_field :phone,
+      required: address.require_phone?,
+      autocomplete: "#{address_type} home tel"
+    %>
   </div>
 
   <% if Spree::Config[:alternative_shipping_phone] %>

--- a/templates/app/views/spree/checkout/steps/address_step/_address_inputs.html.erb
+++ b/templates/app/views/spree/checkout/steps/address_step/_address_inputs.html.erb
@@ -6,13 +6,8 @@
 
   <% if Spree::Config[:company] %>
     <div class="text-input">
-      <%= label_tag :todo, "#{I18n.t("spree.company")}:" %>
-
-      <%= text_field_tag "#{form.object_name}[company]",
-        address.company,
-        id: :todo,
-        autocomplete: "#{address_type} organization"
-      %>
+      <%= form.label :company, "#{I18n.t("spree.company")}:" %>
+      <%= form.text_field :company, autocomplete: "#{address_type} organization" %>
     </div>
   <% end %>
 

--- a/templates/app/views/spree/checkout/steps/address_step/_address_inputs.html.erb
+++ b/templates/app/views/spree/checkout/steps/address_step/_address_inputs.html.erb
@@ -27,21 +27,19 @@
   </div>
 
   <div class="select-input">
-    <% generate_address_id(form, "country_id").tap do |country_id| %>
-      <%= label_tag country_id, "#{I18n.t("spree.country")}:" %>
+    <%= form.label :country_id, "#{I18n.t("spree.country")}:" %>
 
-      <%= form.collection_select(
-        :country_id,
-        available_countries,
-        :id,
-        :name,
-        {},
-        autocomplete: "#{address_type} country-name",
-        class: 'js-trigger-state-change',
-        required: true,
-        "data-state-container": "##{address_type} .js-address-fields"
-      ) %>
-    <% end %>
+    <%= form.collection_select(
+      :country_id,
+      available_countries,
+      :id,
+      :name,
+      {},
+      autocomplete: "#{address_type} country-name",
+      class: 'js-trigger-state-change',
+      required: true,
+      "data-state-container": "##{address_type} .js-address-fields"
+    ) %>
   </div>
 
   <% if Spree::Config[:address_requires_state] %>

--- a/templates/app/views/spree/checkout/steps/address_step/_address_inputs.html.erb
+++ b/templates/app/views/spree/checkout/steps/address_step/_address_inputs.html.erb
@@ -100,16 +100,8 @@
 
   <% if Spree::Config[:alternative_shipping_phone] %>
     <div class="text-input">
-      <% generate_address_id(form, "alternative_phone").tap do |alternative_phone_id| %>
-        <%= label_tag alternative_phone_id, "#{I18n.t("spree.alternative_phone")}:" %>
-
-        <%= text_field_tag "#{form.object_name}[alternative_phone]",
-          address.alternative_phone,
-          type: :tel,
-          id: alternative_phone_id,
-          autocomplete: "#{address_type} tel"
-        %>
-      <% end %>
+      <%= form.label :alternative_phone, "#{I18n.t("spree.alternative_phone")}:" %>
+      <%= form.telephone_field :alternative_phone, autocomplete: "#{address_type} tel" %>
     </div>
   <% end %>
 </div>

--- a/templates/app/views/spree/checkout/steps/address_step/_address_inputs.html.erb
+++ b/templates/app/views/spree/checkout/steps/address_step/_address_inputs.html.erb
@@ -17,15 +17,8 @@
   </div>
 
   <div class="text-input">
-    <% generate_address_id(form, "address2").tap do |address2_id| %>
-      <%= label_tag address2_id, "#{I18n.t("spree.street_address_2")}:" %>
-
-      <%= text_field_tag "#{form.object_name}[address2]",
-        address.address2,
-        id: address2_id,
-        autocomplete: "#{address_type} address-line2"
-      %>
-    <% end %>
+    <%= form.label :address2, "#{I18n.t("spree.street_address_2")}:" %>
+    <%= form.text_field :address2, autocomplete: "#{address_type} address-line2" %>
   </div>
 
   <div class="text-input">

--- a/templates/app/views/spree/checkout/steps/address_step/_address_inputs.html.erb
+++ b/templates/app/views/spree/checkout/steps/address_step/_address_inputs.html.erb
@@ -81,16 +81,12 @@
   <% end %>
 
   <div class="text-input">
-    <% generate_address_id(form, "zipcode").tap do |zipcode_id| %>
-      <%= label_tag zipcode_id, "#{I18n.t("spree.zip")}:" %>
+    <%= form.label :zipcode, "#{I18n.t("spree.zip")}:" %>
 
-      <%= text_field_tag "#{form.object_name}[zipcode]",
-        address.zipcode,
-        id: zipcode_id,
-        required: address.require_zipcode?,
-        autocomplete: "#{address_type} postal-code"
-      %>
-    <% end %>
+    <%= form.text_field :zipcode,
+      required: address.require_zipcode?,
+      autocomplete: "#{address_type} postal-code"
+    %>
   </div>
 
   <div class="text-input">


### PR DESCRIPTION
## Blockers 

Requires https://github.com/nebulab/solidus_starter_frontend/pull/206 to be merged first.

## Goal

As a Solidus Starter Frontend user
I want the address form to be refactored
So that the form will be easier to maintain

## Screenshots

![image](https://user-images.githubusercontent.com/61476/142175915-7ad3932a-9acb-4d61-bf3b-16fe605800da.png)

## Notes

* I skipped the `use_billing` and `save_user_address` check boxes because they are not attributes of Order.

## Types of changes

- N/A: Bug fix (non-breaking change which fixes an issue)
- N/A: New feature (non-breaking change which adds functionality)
- N/A: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- N/A: My change requires a change to the documentation.
- N/A: I have updated the documentation accordingly.
