### PR TITLE
Use FormBuilder methods for user forms

### DIFF
--- a/templates/app/views/spree/user_passwords/new.html.erb
+++ b/templates/app/views/spree/user_passwords/new.html.erb
@@ -4,19 +4,13 @@
   <%= form_for Spree::User.new, as: :spree_user, url: spree.reset_password_path, html: { class: "auth-form" } do |f| %>
     <div class="auth-form__input-wrapper">
       <div class="text-input">
-        <%= label_tag :spree_user_email, "#{t("spree.email")}:" %>
-
-        <%= text_field_tag 'spree_user[email]',
-          nil,
-          type: 'email',
-          id: 'spree_user_email',
-          placeholder: 'name@example.com'
-        %>
+        <%= f.label :email, "#{t("spree.email")}:" %>
+        <%= f.email_field :email, placeholder: 'name@example.com' %>
       </div>
     </div>
 
     <div class="auth-form__input-wrapper">
-      <%= button_tag(
+      <%= f.button(
         t("spree.reset_password"),
         class: 'button-primary button-primary--full-width',
         name: :commit

--- a/templates/app/views/spree/user_sessions/new.html.erb
+++ b/templates/app/views/spree/user_sessions/new.html.erb
@@ -6,27 +6,15 @@
   <%= form_for Spree::User.new, as: :spree_user, url: spree.create_new_session_path, html: { class: "auth-form" } do |f| %>
     <div class="auth-form__input-wrapper">
       <div class="text-input">
-        <%= label_tag :spree_user_email, "#{t("spree.email")}:" %>
-
-        <%= text_field_tag 'spree_user[email]',
-          nil,
-          type: 'email',
-          id: 'spree_user_email',
-          placeholder: 'name@example.com'
-        %>
+        <%= f.label :email, "#{t("spree.email")}:" %>
+        <%= f.email_field :email, placeholder: 'name@example.com' %>
       </div>
     </div>
 
     <div class="auth-form__input-wrapper">
       <div class="text-input">
-        <%= label_tag :spree_user_password, "#{t("spree.password")}:" %>
-
-        <%= text_field_tag 'spree_user[password]',
-          nil,
-          type: :password,
-          id: :spree_user_password,
-          placeholder: "p455w0rd"
-        %>
+        <%= f.label :password, "#{t("spree.password")}:" %>
+        <%= f.password_field :password, placeholder: "p455w0rd" %>
       </div>
     </div>
 
@@ -36,7 +24,7 @@
     </div>
 
     <div class="auth-form__input-wrapper">
-      <%= button_tag(
+      <%= f.button(
         t("spree.login"),
         class: 'button-primary button-primary--full-width',
         name: :commit


### PR DESCRIPTION
## Blockers 

Depends on https://github.com/nebulab/solidus_starter_frontend/pull/206 to be merged first.

## Goal

As a Solidus Starter Frontend user
I want to use FormBuilder methods on the user forms
So that the forms would be easier to maintain and test

## Screenshots

### http://localhost:3000/login

![image](https://user-images.githubusercontent.com/61476/142383951-1d9aec2c-3078-42ea-9c6b-cc29c8e3b5af.png)

### http://localhost:3000/password/recover

![image](https://user-images.githubusercontent.com/61476/142384194-c09c94c7-17ed-43c2-9ebe-cddf9e93a601.png)

## Types of changes

- N/A: Bug fix (non-breaking change which fixes an issue)
- N/A: New feature (non-breaking change which adds functionality)
- N/A: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- N/A: My change requires a change to the documentation.
- N/A: I have updated the documentation accordingly.
