### PR TITLE
Remove statement saying we'll make Solidus Auth Devise optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ gem 'solidus_sample'
 And replace all the references of the string `Spree::Frontend::Config` in your
 project with `SolidusStarterFrontend::Config`.
 
-You'll also need to make sure that [Solidus Auth Devise]
-(https://github.com/solidusio/solidus_auth_devise) is installed in your
-application.
+You'll also need to make sure that
+[Solidus Auth Devise](https://github.com/solidusio/solidus_auth_devise)
+is installed in your application.
 
 ### Frontend installation
 

--- a/README.md
+++ b/README.md
@@ -41,9 +41,8 @@ bin/rails generate solidus:install --auto-accept
 
 Please note that `--auto-accept` will add
 [Solidus Auth Devise](https://github.com/solidusio/solidus_auth_devise)
-to your application. At the moment, SolidusStarterFrontend requires the
-application to include the gem. In the future, we'll make Solidus Auth Devise
-optional.
+to your application. SolidusStarterFrontend requires the application to include
+the gem.
 
 ### For existing stores
 


### PR DESCRIPTION
Goal
----

As a solidus_starter_frontend maintainer

I want to remove the following text from the README:

> At the moment, SolidusStarterFrontend requires the application to
include the gem. In the future, we'll make Solidus Auth Devise optional.

So that frontend users don't expect that we'll make Solidus Auth Devise
optional any time soon.

## Types of changes

- N/A: Bug fix (non-breaking change which fixes an issue)
- N/A: New feature (non-breaking change which adds functionality)
- N/A: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- N/A: My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
